### PR TITLE
#27: add index.html fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <a name="intro"></a>
 ### Intro
 
-[Enonic XP](https://enonic.com/developer-tour) library for serving assets from a folder in the application resource structure. Intended for setting up XP endpoints that serve static resources from an XP app's JAR file, in a cache-optimized way. So basically the same thing as `assetUrl`, but allows you more control:
+[Enonic XP](https://enonic.com/developer-tour) library for serving assets from a folder in the application resource structure. Intended for setting up XP endpoints that serve static resources from an XP app's JAR file, in a cache-optimized way. So basically the same thing as `assetUrl`, but with more features and control:
 
 - **Caching behaviour:** With `assetUrl`, you get a URL where the current installation/version of the app is baked in as a hash. It will change whenever the app is updated, forcing browsers to skip their locally cached resources and request new ones, even if the resource wasn't changed during the update. Using lib-static with [immutable assets](docs/index.adoc#mutable-assets) retains stable URLs and has several ways to adapt the header to direct browsers' caching behavior more effectively, even for mutable assets.
 - **Endpoint URLs:** make your resource endpoints anywhere, 
@@ -18,6 +18,7 @@
 - **Control resource folders:** As long as the resources are built into the app JAR, resources can be served from anywhere - even with multiple lib-static instances at once: serve from multiple specific-purpose folders, or use multi-instances to specify multiple rules from the same folder. 
   - Security issues around this are handled in the standard usage: a set root folder is required (and not at the JAR root), and URL navigation out from it is prevented. But if you still REALLY want to circumvent this, there is a lower-level API too.
 - **Error handling:** 500-type errors can be set to throw instead of returning an error response - leaving the handling to you.
+- **Index fallback:** A URL that refers to the name of a directory that contains a fallback file `index.html`, will fetch the fallback file (if no fallback file is found: regular 404 response).
 
 <br/>
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -442,7 +442,7 @@ const getStatic = libStatic.buildGetter({
             return "max-age=3600";
         }
         if (resource.getSize() < 100) {
-            return "must-revalidate";
+            return "no-cache";
         }
         return null;
     }

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -20,7 +20,7 @@ Some relevant sources: link:https://web.dev/http-cache/[web.dev], link:https://e
 [[why]]
 === Why use lib-static instead of portal.assetUrl?
 
-Enonic XP already comes with an link:https://developer.enonic.com/docs/xp/stable/runtime/engines/asset-service[asset service], where you can just put resources in the _/assets_ root folder and use `portal.assetUrl(resourcePath)` to generate URLs from where to fetch them. Lib-static basically does the same thing, but allows you more control:
+Enonic XP already comes with an link:https://developer.enonic.com/docs/xp/stable/runtime/engines/asset-service[asset service], where you can just put resources in the _/assets_ root folder and use `portal.assetUrl(resourcePath)` to generate URLs from where to fetch them. Lib-static basically does the same thing, but with more features and control:
 
 - **Caching behaviour:** With `assetUrl`, you get a URL where the current installation/version of the app is baked in as a hash. It will change whenever the app is updated, forcing browsers to skip their locally cached resources and request new ones, even if the resource wasn't changed during the update. Using lib-static with link:#mutable-assets[immutable assets] retains stable URLs and has several ways to adapt the header to direct browsers' caching behaviour more effectively, even for mutable assets.
 - **Endpoint URLs:** make your resource endpoints anywhere,
@@ -28,6 +28,7 @@ Enonic XP already comes with an link:https://developer.enonic.com/docs/xp/stable
 - **Control resource folders:** As long as the resources are built into the app JAR, resources can be served from anywhere - even with multiple lib-static instances at once: serve from multiple specific-purpose folders, or use multi-instances to specify multiple rules from the same folder.
   - Security issues around this are handled in the standard usage: a set root folder is required (and not at the JAR root), and URL navigation out from it is prevented. But if you still REALLY want to circumvent this, there is a lower-level API too.
 - **Error handling:** 500-type errors can be set to throw instead of returning an error response - leaving the handling to you.
+- **Index fallback:** A URL that refers to the name of a directory that contains a fallback file (`index.html`), will fetch the fallback file.
 
 {zwsp} +
 {zwsp} +
@@ -68,9 +69,10 @@ const libStatic = require('/lib/enonic/static');
 [[examples]]
 == Usage examples
 
+{zwsp} +
 
 [[example-service]]
-=== A simple service
+=== 1. A simple service
 
 One way to use lib-static is in an link:https://developer.enonic.com/docs/xp/stable/runtime/engines/http-service[XP service], and use it to fetch the resource and serve the entire response object to the front end.
 
@@ -93,7 +95,7 @@ exports.get = function(request) {
 
 
 [[example-service-urls]]
-==== Resource path and URL
+==== a) Resource path and URL
 If this was the entire content of _src/main/resources/services/servemyfolder/servemyfolder.js_ in an app with the app name/key `my.xp.app`, then XP would respond to GET requests at the URL `<domain>/_/service/my.xp.app/servemyfolder` (where `<domain>` is the domain or other prefix, depending on vhosts etc).
 
 NOTE: Using link:https://developer.enonic.com/docs/xp/stable/api/lib-portal#serviceurl[libPortal.serviceUrl] is recommended (for example:  `libPortal.serviceUrl('servemyfolder')`).
@@ -107,22 +109,28 @@ It's recommended to use `.buildGetter` in an link:https://developer.enonic.com/d
 
 👉 See the link:#example-path[path resolution] and link:#api-buildgetter[API reference] below for more details.
 
-==== Output
-If _my/folder/some/subdir/some.file_ exists as a (readable) file, a full link:https://developer.enonic.com/docs/xp/stable/framework/http#http-response[XP response object] is returned. Most importantly:
+[[example-output]]
+==== b) Output
+If _my/folder/some/subdir/some.file_ exists as a (readable) file, a full link:https://developer.enonic.com/docs/xp/stable/framework/http#http-response[XP response object] is returned. Typically something like:
 
 [source,javascript,options="nowrap"]
 ----
 {
   status: 200,
-  body: "<file content from some/subdir/some.file>"
+  body: "File content from some/subdir/some.file",
+  contentType: "text/plain",
+  headers: {
+    ETag: "1234567890abcdef",
+    "Cache-Control": "public, max-age=31536000, immutable"
+  }
 }
 ----
 
-There will also be headers for Cache-Control, ETag and contentType. If the file doesn't exist (or other circumstances), other statuses are returned: 304, 400, 404 and 500. And of course, `body` can be text or binary, depending on the file and type.
+If the link:#example-etag[ETag/client-cache functionality] is active and the file hasn't changed since a previous download, a `status:304` response is sent (and _only_ `status` - instructing browsers to use locally cached resources and saving some downloading time).
 
-👉 link:#behaviour[Default behaviour]
+👉 link:#behaviour[API: response and default behaviour]
 
-==== Syntax variations
+==== c) Syntax variations
 Above, `'my/folder'` is provided to `.buildGetter` as a named `root` attribute in a parameters object. If you prefer a simpler syntax (and don't need additional link:#example-options[options]), just use a string as a first-positional argument:
 
 [source,javascript,options="nowrap"]
@@ -145,7 +153,7 @@ exports.get = libStatic.buildGetter('my/folder');
 
 
 [[example-urls]]
-=== Resource URLs
+=== 2. Resource URLs
 Once a service (or a link:#example-path[different endpoint]) has been set up like this, it can serve the resources as regular assets to the frontend. An link:https://developer.enonic.com/docs/xp/stable/runtime/engines/webapp-engine[XP webapp] for example just needs to resolve the base URL. In the previous example we set up the the _servemyfolder_ service, so we can just use `serviceUrl` here to call on it from a webapp, for example:
 
 .src/main/resources/webapp/webapp.js:
@@ -180,7 +188,7 @@ exports.get = function(req) {
 
 
 [[example-options]]
-=== Options and syntax
+=== 3. Options and syntax
 
 The behaviour of the returned getter function from `.buildGetter` can be controlled with more link:#options[options], in addition to the `root`.
 
@@ -210,7 +218,7 @@ libStatic.buildGetter('my/folder', {
 
 
 [[example-path]]
-=== Path resolution on other endpoints
+=== 4. Path resolution on other endpoints
 
 Usually, the path to the resource file (relative to the root folder) is link:#example-service-urls[determined from the request]. But this depends on several things: the request object must contain a `rawPath` and `contextPath` attribute to compare, and there must be some routing involved: the controller must be able to accept requests from sub-URIs. In link:https://developer.enonic.com/docs/xp/stable/runtime/engines/http-service[XP services] (and link:https://developer.enonic.com/docs/xp/stable/runtime/engines/webapp-engine[XP webapps], but with caveats) this is supported out of the box, making it easiest to use a service to implement an endpoint.
 
@@ -226,7 +234,7 @@ From this request, the relative resource path is resolved to _some/subdir/some.f
 
 
 [[example-getcleanpath]]
-==== getCleanPath
+==== a) getCleanPath
 However, there can be cases where you need to customize the relative-asset-path resolution - for example, using an link:https://developer.enonic.com/docs/xp/stable/cms/mappings[XP controller mapping] for setting up an endpoint that uses lib-static.
 
 Send an link:#example-options[option] function `getCleanPath` to `.buildGetter`. `getCleanPath` takes the `request` argument and returns a relative asset path. The rest is up to you:
@@ -273,7 +281,7 @@ exports.get = libStatic.buildGetter({
 
 
 [[example-webapp]]
-=== A webapp with lib-router
+=== 5. A webapp with lib-router
 
 Combining `.getCleanPath` with link:https://developer.enonic.com/docs/router-library/master[lib-router] can be an easy alternative to setting up separate services the way we did above. Just let the webapp itself use lib-router to detect sub-URI's and handle the resource serving too, all from the same controller:
 
@@ -342,7 +350,7 @@ Prefixing with `request.contextPath` solves it in this case. Your mileage may va
 
 
 [[example-content]]
-=== Custom content type handling
+=== 6. Custom content type handling
 
 By default, lib-static detects link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types[MIME-type] automatically. But you can use the `contentType` link:#example-options[option] to override it. Either way, the result is a string returned with link:#behaviour[the response object].
 
@@ -398,7 +406,7 @@ const getStatic = libStatic.buildGetter({
 
 
 [[example-cache]]
-=== Custom Cache-Control headers
+=== 7. Custom Cache-Control headers
 
 The `cacheControl` link:#example-options[option] controls the link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control['Cache-Control'] string that's returned in the header with a successful resource fetch. The string value, if any, directs the intraction between a browser and the server on subsequent requests for the same resource. By link:#behaviour[default] the string `"public, max-age=31536000, immutable"` is returned, the `cacheControl` option overrides this to return a different string, or switch it off:
 
@@ -447,7 +455,7 @@ const getStatic = libStatic.buildGetter({
 
 
 [[example-etag]]
-=== ETag switch
+=== 8. ETag switch
 
 By link:#behaviour[default], an ETag is generated from the asset and sent along with the response as a header, in XP prod run mode. In link:https://developer.enonic.com/docs/enonic-cli/master/dev#start[XP dev mode], no ETag is generated.
 
@@ -467,7 +475,7 @@ const getStatic = libStatic.buildGetter({
 
 
 [[example-errors]]
-=== Errors: throw instead of return
+=== 9. Errors: throw instead of return
 
 By link:#behaviour[default], runtime errors during `.get` or during the returned getter function from `.buildGetter` will log the error message and return a 500-status response to the client.
 
@@ -496,7 +504,7 @@ exports.get = function(req) {
 
 
 [[example-multi]]
-=== Multiple instances
+=== 10. Multiple instances
 
 Lib-static can be set up to respond with several instances in parallel, thereby defining different rules for different files/folders/scenarios.
 
@@ -507,27 +515,28 @@ Lib-static can be set up to respond with several instances in parallel, thereby 
 
 
 [[example-get]]
-=== Low-level: .get
+=== 11. Low-level: .get
 
 Lib-static exposes a second function `.get` (in addition to `.buildGetter`), for doing a direct resource fetch when the resource path is already known/resolved. The idea is to allow closer control with each call: implement your own logic and handling around it.
 
 NOTE: For most scenarios though, you'll probably want to use link:#api-buildgetter[`.buildGetter`].
 
-==== Similarities
+==== a) Similarities
 - Just like the getter function returned by `.buildGetter`, `.get` also returns a link:#behaviour[full response object] with status, body, content type and a generated ETag, and has error detection and corresponding responses (statuses 400, 404 and 500).
 - The link:#options[options] are also mostly the same.
 
-==== Differences
+==== b) Differences
 `.get` is different from `.buildGetter` in these ways:
 
 - `.get` is intended for lower-level usage (wraps less functionality, but gives the opportunity for even more controlled usage).
 - Only one call: whereas `.buildGetter` sets up a reusable getter function, `.get` _is_ the getter function.
 - No root folder is set up with `.get`. In every call, instead of the `request` argument, `.get` takes a full, absolute resource `path` (relative to JAR root) string. This allows _any valid path_ inside the JAR except the root `/` itself - including source code! **Be careful** how you resolve the `path` string in the controller to avoid security flaws, such as opening a service to reading _any file in the JAR_, etc.
 - Since `.get` doesn't resolve the resource path from the request, there's no `getCleanPath` override option here.
-- There is no check for matching ETag (`If-None-Match` header), and no functionality to return a body-less status 304. `.get` always tries to fetch the resource.
+- There is no check in `.get` for matching ETag (`If-None-Match` header), and no functionality to return a body-less status 304. `.get` always tries to fetch the resource.
+- There is no link:#index-fallback[index fallback] functionality in `.get`.
 
 
-==== Examples
+==== c) Examples
 
 An example service _getSingleStatic.es6_ that always returns a particular asset _/public/my-folder/another-asset.css_ from the JAR:
 
@@ -688,23 +697,47 @@ For example:
 }
 ----
 
+👉  link:#example-output[Output: intro/example]
+
+{zwsp} +
+
+[[index-fallback]]
+==== Index fallback
+
+If the URL points to a folder instead of a file, and that folder contains a fallback file (`index.html`), the fallback file is served with the appropriate contentType and a cache-busting Cache-Control header.
+
+If the folder-name URL does not end with a trailing slash, this slash is automatically added via a redirect. This is to ensure that later relative links will work.
+
+This is a feature in link:#api-buildgetter[.buildGetter], but not link:#api-get[.get] - if you use .get you must implement it yourself.
+
+
+
 {zwsp} +
 
 [[status]]
 ==== status
 
-Follows standard link:https://en.wikipedia.org/wiki/List_of_HTTP_status_codes[HTTP error codes]: 200 - OK, 400 - Bad Request, 404 - Not Found. And for [.buildGetter], 304 - Not Modified, signifying a matching ETag and triggering a browser to use its local cached asset. On other errors: 500, and possibly an error message in `body`.
+Standard link:https://en.wikipedia.org/wiki/List_of_HTTP_status_codes[HTTP error codes]:
+
+- `200` (OK): successful, resource fetched. Either the resource path pointed to a readable file, or to a folder where a link:#index-fallback[index fallback] file was found (index fallback is an automatic feature of link:#api-buildgetter[.buildGetter], but not link:#api-get[.get]).
+- `303` (Redirect): resource path hit a folder with an index fallback file in it, but the path doesnt end with a slash. It needs the slash, so make a redirect to add it. This is an automatic feature of link:#api-buildgetter[.buildGetter], but not link:#api-get[.get].
+- `304` (Not Modified): matching ETag - the requested resource hasn't changed since a previous download. So a response with this status only is a signal to browsers to reuse their locally cached resource instead of downloading it again. This is an automatic feature of link:#api-buildgetter[.buildGetter], but not link:#api-get[.get].
+- `400` (Bad Request): the resource path is illegal, that is, resolves to an empty path or contains illegal characters: `: | < > ' " ´ * ?` or backslash or backtick.
+- `404` (Not Found): a valid resource path, but it doesn't point to a readable file or a directory with an index fallback in it.
+- `500` (Error): a server-side error happened. Details will be found in the server log, but not returned to the user.
 
 {zwsp} +
 
 [[body]]
 ==== body
 
-Content of the requested asset, or an error message.
+On status-`200` responses, this is the content of the requested asset. Can be text or binary, depending on the file and type. May also carry error messages.
 
-When returning a resource, this content is not a string but a **resource stream** from link:https://developer.enonic.com/docs/xp/stable/api/lib-io[ioLib] (see resource.getStream). This works seamlessly for returning both binary and non-binary files in the response directly to browsers. But might be less straightforward when writing tests or otherwise intercepting the output.
+Empty on status-`304`.
 
-In link:https://developer.enonic.com/docs/enonic-cli/master/dev#start[XP dev mode], 400- and and 404-type errors will have the requested asset path in the body.
+Interally in XP (before returning it to the browser), this content is not a string but a **resource stream** from link:https://developer.enonic.com/docs/xp/stable/api/lib-io[ioLib] (see resource.getStream). This works seamlessly for returning both binary and non-binary files in the response directly to browsers. But might be less straightforward when writing tests or otherwise intercepting the output.
+
+In link:https://developer.enonic.com/docs/enonic-cli/master/dev#start[XP dev mode], `400`- and and `404`-status errors will have the requested asset path in the body.
 
 {zwsp} +
 
@@ -720,9 +753,11 @@ link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
 
 **Default headers** optimized for immutable and link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#private_browser_caches[browser cached] resources.
 
+Typically, there's an `ETag` and a `Cache-Control` attribute, but this may depend on whether they are active in link:#options[options], and on XP runtime mode: ETag is usually switched off in dev mode.
+
 [NOTE]
 ====
-Mutable assets *should not* be served with the default 'Cache-Control' header `'public, max-age=31536000, immutable'`.
+**Important:** mutable assets should not be served with the default 'Cache-Control' header: `'public, max-age=31536000, immutable'`.
 
 👉  link:#mutable-headers[Handling mutable assets]
 ====
@@ -945,12 +980,14 @@ If you have mutable assets in your project, there are several ways you could imp
 == TODO: Later versions
 
 === Options params
-- `index` (string or array of strings): filename(s) (without path) to fall back to, look for and serve, in cases where the asset path requested is a folder. If not set, requesting a folder will yield an error. Implementaion: before throwing a 404, check if postfixing any of the chosen /index files (with the slash) resolves it. If so, return that.
-  The rest is up to the developer, and their responsibility how it's used: what htm/html/other they explicitly add in this parameter. And cache headers, just same as if they had asked directly for the index file.
+- `indexFallback` (`false`, string, string array, object or function(absolutePath -> stringOrStringarrayOrFalse)): filename(s) (without slashes or path) to fall back to, look for and serve, in cases where the asset path requested is a folder. If not set, requesting a folder will yield an error. Implementaion: before throwing a 404, check if postfixing any of the chosen /index files (with the slash) resolves it. If so, return that.
+  The rest is up to the developer, and their responsibility how it's used: what htm/html/other they explicitly add in this parameter. And cache headers, just same as if they had asked directly for the index file. Set to `false` (or have the object or function return it) to skip the index fallback.
 
 === Response
 - `'Last-Modified'` header, determined on file modified date
-- `'Accept-Ranges': 'bytes'` header. Implement range handling.
+
+=== Range handling
+- `'Accept-Ranges': 'bytes'` header
 
 === .resolvePath(globPath/regex, root)
 Probably not in this lib? Worth mentioning though:
@@ -964,3 +1001,4 @@ For example, if a fingerprinted asset _bundle.92d34fd72.js_ is built into _/stat
 ----
 - Besides, `resolvePath` can/should be part of a different library. Can be its own library (‘lib-resolvepath’?) or part of some other general-purpose lib, for example lib-util.
 - In dev mode, `resolvePath` will often find more than one match and select the most recently updated one (and should log it at least once if that’s the case). In prod mode, it should throw an error if more than one is found, and if only one is found, cache it internally.
+

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -864,7 +864,7 @@ Mutable assets _can_ be handled by this library (since ETag support is in place 
 [source,javascript,options="nowrap"]
 ----
 {
-    'Cache-Control': 'must-revalidate',
+    'Cache-Control': 'no-cache',
 }
 ----
 +
@@ -900,7 +900,7 @@ If you have mutable assets in your project, there are several ways you could imp
 
         // ...because the options object overrides the Cache-Control header (and only that - etag is preserved, importantly):
         {
-            cacheControl: 'must-revalidate'
+            cacheControl: 'no-cache'
         }
     );
 ----

--- a/src/main/resources/lib/enonic/static/constants.es6
+++ b/src/main/resources/lib/enonic/static/constants.es6
@@ -1,0 +1,15 @@
+/////////////////////////////////////////////////////////  Cache-control constants:
+
+const DEFAULT_MAX_AGE = 31536000;
+
+exports.DEFAULT_CACHE_CONTROL_FIELDS = [
+    "public",
+    "max-age=" + DEFAULT_MAX_AGE,
+    "immutable"
+];
+const DEFAULT_CACHE_CONTROL = exports.DEFAULT_CACHE_CONTROL_FIELDS.join(", ");
+
+const INDEXFALLBACK_CACHE_CONTROL = 'no-cache';
+
+exports.DEFAULT_CACHE_CONTROL = DEFAULT_CACHE_CONTROL;
+exports.INDEXFALLBACK_CACHE_CONTROL = INDEXFALLBACK_CACHE_CONTROL;

--- a/src/main/resources/lib/enonic/static/index.es6
+++ b/src/main/resources/lib/enonic/static/index.es6
@@ -2,11 +2,14 @@ const etagReader = require('/lib/enonic/static/etagReader');
 const optionsParser = require('/lib/enonic/static/options');
 const ioLib = require('/lib/enonic/static/io');
 const runMode = require('/lib/enonic/static/runMode');
+const constants = require('/lib/enonic/static/constants');
+
+/////////////////////////////////////////////////////////////////////////////  Response builder functions
 
 const getResponse200 = (path, resource, contentTypeFunc, cacheControlFunc, etag, fallbackPath) => {
     const contentType = contentTypeFunc(fallbackPath || path, resource);
     const cacheControlHeader = fallbackPath
-        ? 'must-revalidate'
+        ? constants.INDEXFALLBACK_CACHE_CONTROL
         : cacheControlFunc(path, resource, contentType);
 
     // Preventing any keys under 'header' with null/undefined values (since those cause NPE):

--- a/src/main/resources/lib/enonic/static/options.es6
+++ b/src/main/resources/lib/enonic/static/options.es6
@@ -1,15 +1,6 @@
 const ioLib = require('/lib/enonic/static/io');
+const constants = require('/lib/enonic/static/constants');
 
-const DEFAULT_MAX_AGE = 31536000;
-
-exports.DEFAULT_CACHE_CONTROL_FIELDS = [
-    "public",
-    "max-age=" + DEFAULT_MAX_AGE,
-    "immutable"
-];
-
-const DEFAULT_CACHE_CONTROL = exports.DEFAULT_CACHE_CONTROL_FIELDS.join(", ");
-exports.DEFAULT_CACHE_CONTROL = DEFAULT_CACHE_CONTROL;
 
 const verifyEtagOption = (etag) => {
     if (etag !== true && etag !== false && etag !== undefined) {
@@ -49,7 +40,7 @@ const getCacheControlFunc = (cacheControl) => {
 
     if (cacheControl === undefined || cacheControl === true) {
         // Ignoring other absent/no-override values
-        return () => DEFAULT_CACHE_CONTROL;
+        return () => constants.DEFAULT_CACHE_CONTROL;
     }
 
     const argType = typeof cacheControl;
@@ -62,7 +53,7 @@ const getCacheControlFunc = (cacheControl) => {
         return (path, resource, mimeType) => {
             const result = cacheControl(path, resource, mimeType);
             if (result === null) {
-                return DEFAULT_CACHE_CONTROL;
+                return constants.DEFAULT_CACHE_CONTROL;
             }
             return result;
         }

--- a/src/test/java/lib/enonic/libStatic/IoMock.java
+++ b/src/test/java/lib/enonic/libStatic/IoMock.java
@@ -7,11 +7,12 @@ import com.enonic.xp.script.bean.ScriptBean;
 import com.enonic.xp.util.MediaTypes;
 import com.google.common.io.ByteSource;
 import com.google.common.net.MediaType;
-import org.apache.commons.io.Charsets;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class IoMock
     implements ScriptBean
@@ -42,7 +43,7 @@ public class IoMock
     }
 
     public String readText(ByteSource byteSource) throws IOException {
-        return byteSource.asCharSource(Charsets.UTF_8).read();
+        return byteSource.asCharSource( StandardCharsets.UTF_8 ).read();
     }
 
     private ResourceKey toResourceKey( final Object value )

--- a/src/test/resources/lib/enonic/static/get-test.es6
+++ b/src/test/resources/lib/enonic/static/get-test.es6
@@ -1,5 +1,4 @@
-const DEFAULT_CACHE_CONTROL = require('/lib/enonic/static/options').DEFAULT_CACHE_CONTROL;
-
+const constants = require('/lib/enonic/static/constants');
 const ioMock = require('/lib/enonic/static/ioMock');
 
 const t = require('/lib/xp/testing');
@@ -31,79 +30,6 @@ mockOptionsparser();
 const lib = require('./index');
 
 //////////////////////////////////////////////////////////////////  HELPERS
-
-                                                                                                                        const prettify = (obj, label, suppressCode= false, indent = 0) => {
-                                                                                                                            let str = " ".repeat(indent) + (
-                                                                                                                                label !== undefined
-                                                                                                                                    ? label + ": "
-                                                                                                                                    : ""
-                                                                                                                            );
-
-                                                                                                                            if (typeof obj === 'function') {
-                                                                                                                                if (!suppressCode) {
-                                                                                                                                    return `${str}···· (function)\n${" ".repeat(indent + 4)}` +
-                                                                                                                                        obj.toString()
-                                                                                                                                            .replace(
-                                                                                                                                                /\r?\n\r?/g,
-                                                                                                                                                `\n${" ".repeat(indent + 4)}`
-                                                                                                                                            ) +
-                                                                                                                                        "\n" + " ".repeat(indent) + "····"
-                                                                                                                                        ;
-                                                                                                                                } else {
-                                                                                                                                    return `${str}···· (function)`;
-                                                                                                                                }
-
-                                                                                                                            } else if (Array.isArray(obj)) {
-                                                                                                                                return obj.length === 0
-                                                                                                                                    ? `${str}[]`
-                                                                                                                                    : (
-                                                                                                                                        `${str}[\n` +
-                                                                                                                                        obj.map(
-                                                                                                                                            (item, i) =>
-                                                                                                                                                prettify(item, i, suppressCode, indent + 4)
-                                                                                                                                        )
-                                                                                                                                            .join(",\n") +
-                                                                                                                                        `\n${" ".repeat(indent)}]`
-                                                                                                                                    );
-
-                                                                                                                            } else if (obj && typeof obj === 'object') {
-                                                                                                                                try {
-                                                                                                                                    if (Object.keys(obj).length === 0) {
-                                                                                                                                        return `${str}{}`;
-                                                                                                                                    } else {
-                                                                                                                                        return `${str}{\n` +
-                                                                                                                                            Object.keys(obj).map(
-                                                                                                                                                key => prettify(obj[key], key, suppressCode, indent + 4)
-                                                                                                                                            ).join(",\n") +
-                                                                                                                                            `\n${" ".repeat(indent)}}`
-                                                                                                                                    }
-                                                                                                                                } catch (e) {
-                                                                                                                                    log.info(e);
-                                                                                                                                    return `${str}···· (${typeof obj})\n${" ".repeat(indent + 4)}` +
-                                                                                                                                        obj.toString()
-                                                                                                                                            .replace(
-                                                                                                                                                /\r?\n\r?/g,
-                                                                                                                                                `\n${" ".repeat(indent + 4)}`
-                                                                                                                                            ) +
-                                                                                                                                        "\n" + " ".repeat(indent) + `····`;
-                                                                                                                                }
-                                                                                                                            } else if (obj === undefined || obj === null) {
-                                                                                                                                return `${str}${obj}`;
-                                                                                                                            } else if (JSON.stringify(obj) !== undefined) {
-                                                                                                                                return `${str}` + JSON.stringify(obj, null, 2).replace(
-                                                                                                                                    /\r?\n\r?/g,
-                                                                                                                                    `\n${" ".repeat(indent + 2)}`
-                                                                                                                                );
-                                                                                                                            } else {
-                                                                                                                                return `${str}···· (${typeof obj})\n${" ".repeat(indent + 4)}` +
-                                                                                                                                    obj.toString()
-                                                                                                                                        .replace(
-                                                                                                                                            /\r?\n\r?/g,
-                                                                                                                                            `\n${" ".repeat(indent + 4)}`
-                                                                                                                                        ) +
-                                                                                                                                    "\n" + " ".repeat(indent) + `····`;
-                                                                                                                            }
-                                                                                                                        };
 
 /* Mocks runMode.js, io.js, etagReader.js and options.js.
   Optional params: {
@@ -141,7 +67,7 @@ const doMocks = (params={}, verbose= false) => {
 
     mockedRunmodeFuncs.isDev = (typeof params.isDev === 'boolean' )
         ? () => {
-                                                                                                                        if (verbose) log.info(prettify(params.isDev, "Mocked isDev"));
+                                                                                                                        if (verbose) log.info("Mocked isDev: " + JSON.stringify(params.isDev, null, 2));
             return params.isDev
         }
         : () => false;
@@ -160,21 +86,21 @@ const doMocks = (params={}, verbose= false) => {
 
             const res = ioMock.getResource(data.path, data.exists, data.content);
 
-                                                                                                                        if (verbose) log.info(prettify(data, "Mocked io.getResource(" + JSON.stringify(path) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked io.getResource(" + JSON.stringify(path) + "): " + JSON.stringify(data, null, 2));
             return res;
         }
     );
     mockedIoFuncs.readText = io.readText || (
         (stream) => {
             const text = io.text || ioMock.readText(stream);
-                                                                                                                        if (verbose) log.info(prettify(text,"Mocked io.readText(stream)"));
+                                                                                                                        if (verbose) log.info("Mocked io.readText(stream): " + JSON.stringify(text, null, 2));
             return text;
         }
     );
     mockedIoFuncs.getMimeType = io.getMimeType || (
         (name) => {
             const mimeType = io.mimeType || ioMock.getMimeType(name);
-                                                                                                                        if (verbose) log.info(prettify(mimeType, "Mocked io.getMimeType(" + JSON.stringify(name) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked io.getMimeType(" + JSON.stringify(name) + "): " + JSON.stringify(mimeType, null, 2));
             return mimeType;
         }
     );
@@ -186,7 +112,7 @@ const doMocks = (params={}, verbose= false) => {
     mockedEtagreaderFuncs.read = etagReader.read || (
         (path, etagOverride) => {
             const etag = etagReader.etag || "MockedETagPlaceholder";
-                                                                                                                        if (verbose) log.info(prettify(etag, "Mocked etagReader.read(" + JSON.stringify({path, etagOverride}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked etagReader.read(" + JSON.stringify({path, etagOverride}) + "): " + JSON.stringify(etag, null, 2));
             return etag;
         }
     );
@@ -201,14 +127,14 @@ const doMocks = (params={}, verbose= false) => {
             : ioMock.getMimeType,
         cacheControlFunc: (optionParams.cacheControl !== undefined)
             ? () => optionParams.cacheControl
-            : () => DEFAULT_CACHE_CONTROL
+            : () => constants.DEFAULT_CACHE_CONTROL
     };
     mockedOptionsparserFuncs.parsePathAndOptions = optionParams.parsePathAndOptions || (
         (pathOrOptions, options) => {
             const parsed = (typeof pathOrOptions === 'string')
                 ? { path: pathOrOptions, ...defaultOptions, ...options, ...optionParams }
                 : { ...defaultOptions, ...pathOrOptions, ...optionParams };
-                                                                                                                        if (verbose) log.info(prettify(parsed, "Mocked parseRootAndOptions(" + JSON.stringify({pathOrOptions, options}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked parseRootAndOptions(" + JSON.stringify({pathOrOptions, options}) + "): " + JSON.stringify(parsed, null, 2));
             return parsed;
         }
     );
@@ -217,7 +143,7 @@ const doMocks = (params={}, verbose= false) => {
             const parsed = (typeof rootOrOptions === 'string')
                 ? { root: rootOrOptions, ...defaultOptions, ...options, ...optionParams }
                 : { ...defaultOptions, ...rootOrOptions, ...optionParams };
-                                                                                                                        if (verbose) log.info(prettify(parsed, "Mocked parseRootAndOptions(" + JSON.stringify({rootOrOptions, options}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked parseRootAndOptions(" + JSON.stringify({rootOrOptions, options}) + "): " + JSON.stringify(parsed, null, 2));
             return parsed;
         }
     );
@@ -238,8 +164,8 @@ exports.testGet_innerbehavior_1arg_parsePathAndOptions_isCalled = () => {
     doMocks({
             options: {
                 parsePathAndOptions: (pathOrOptions, options) => {
-                                                                                                                        if (verbose) log.info(prettify(pathOrOptions, "parsePathAndOptions call - pathOrOptions"));
-                                                                                                                        if (verbose) log.info(prettify(options, "parsePathAndOptions call - options"));
+                                                                                                                        if (verbose) log.info("parsePathAndOptions call - pathOrOptions: " + JSON.stringify(pathOrOptions, null, 2));
+                                                                                                                        if (verbose) log.info("parsePathAndOptions call - options: " + JSON.stringify(options, null, 2));
                     // Verify that the arguments of .get are passed into parsePathAndOptions the expected way:
                     t.assertEquals(undefined, options, "parsePathAndOptions: options");
                     t.assertEquals('object', typeof pathOrOptions , "parsePathAndOptions: pathOrOptions");
@@ -271,7 +197,7 @@ exports.testGet_innerbehavior_1arg_parsePathAndOptions_isCalled = () => {
         contentType: 'contentType/string/object/or/function/but/ok',
         etag: 'etag/should/be/boolean/but/ok'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
     t.assertTrue(parsePathAndOptionsWasCalled, "parsePathAndOptionsWasCalled");
 };
 
@@ -281,8 +207,8 @@ exports.testGet_innerbehavior_2arg_parsePathAndOptions_isCalled = () => {
     doMocks({
             options: {
                 parsePathAndOptions: (pathOrOptions, options) => {
-                                                                                                                        if (verbose) log.info(prettify(pathOrOptions, "parsePathAndOptions call - pathOrOptions"));
-                                                                                                                        if (verbose) log.info(prettify(options, "parsePathAndOptions call - options"));
+                                                                                                                        if (verbose) log.info("parsePathAndOptions call - pathOrOptions: " + JSON.stringify(pathOrOptions, null, 2));
+                                                                                                                        if (verbose) log.info("parsePathAndOptions call - options: " + JSON.stringify(options, null, 2));
                     // Verify that the arguments of .get are passed into parsePathAndOptions the expected way:
                     t.assertEquals('object', typeof options, "parsePathAndOptions: options");
                     t.assertEquals('string', typeof pathOrOptions , "parsePathAndOptions: pathOrOptions");
@@ -316,7 +242,7 @@ exports.testGet_innerbehavior_2arg_parsePathAndOptions_isCalled = () => {
             etag: 'etag/should/be/boolean/but/ok'
         }
     );
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
     t.assertTrue(parsePathAndOptionsWasCalled, "parsePathAndOptionsWasCalled");
 };
 
@@ -344,7 +270,7 @@ exports.testGet_innerbehavior_parsePathAndOptions_error_shouldLogAndAbort = () =
         verbose);
 
     const result = lib.get("my/path");
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
     t.assertFalse(getResourceWasCalled, "getResourceWasCalled");
     t.assertFalse(etagReadWasCalled, "etagReadWasCalled");
     t.assertEquals(500, result.status , "result.status");
@@ -404,7 +330,7 @@ exports.testGet_innerbehavior_parsePathAndOptions_outputs_areUsed = () => {
         cacheControl: 'arg/cacheControl/in',
         contentType: 'arg/contentType/in'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
     t.assertTrue(getResourceWasCalled, "getResourceWasCalled");
     t.assertTrue(etagReadWasCalled, "etagReadWasCalled");
     t.assertTrue(cacheControlFuncWasCalled, "cacheControlFuncWasCalled");
@@ -413,6 +339,8 @@ exports.testGet_innerbehavior_parsePathAndOptions_outputs_areUsed = () => {
     t.assertEquals('options/cacheControl/out', result.headers['Cache-Control'], 'cacheControl');
     t.assertEquals('reader/etag/out', result.headers.ETag, 'cacheControl');
     t.assertEquals('options/contentType/out', result.contentType, 'contentType');
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 };
 
 /*
@@ -444,11 +372,12 @@ exports.testGet_innerbehavior_removesLeadingPathSlashesFromPathBeforeGetPathErro
 // Path string argument
 
 exports.testGet_path_string_FullDefaultResponse = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_path_string_FullDefaultResponse:\n");
     doMocks({}, verbose);
 
     const result = lib.get('/assets/asset-test-target.txt');
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/assets/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -460,14 +389,17 @@ exports.testGet_path_string_FullDefaultResponse = () => {
     t.assertEquals('object', typeof result.headers, "result.headers should be an object with ETag and Cache-Control");
     t.assertEquals( "MockedETagPlaceholder", result.headers.ETag, "result.headers should be an object with ETag and Cache-Control");
     t.assertTrue(result.headers.ETag.length > 0, "result.headers should be an object with ETag and Cache-Control");
-    t.assertEquals(DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 };
 exports.testGet_path_option_FullDefaultResponse = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_path_option_FullDefaultResponse:\n");
     doMocks({}, verbose);
 
     const result = lib.get({path: '/assets/asset-test-target.txt'});
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/assets/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -479,15 +411,17 @@ exports.testGet_path_option_FullDefaultResponse = () => {
     t.assertEquals('object', typeof result.headers, "result.headers should be an object with ETag and Cache-Control");
     t.assertEquals( "MockedETagPlaceholder", result.headers.ETag, "result.headers should be an object with ETag and Cache-Control");
     t.assertTrue(result.headers.ETag.length > 0, "result.headers should be an object with ETag and Cache-Control");
-    t.assertEquals(DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 };
 
 exports.testGet_DEV_path_string_FullDefaultResponse_DEV = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_DEV_path_string_FullDefaultResponse_DEV:\n");
     doMocks({isDev: true}, verbose);
 
     const result = lib.get('/assets/asset-test-target.txt');
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/assets/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -499,14 +433,17 @@ exports.testGet_DEV_path_string_FullDefaultResponse_DEV = () => {
     t.assertEquals('object', typeof result.headers, "result.headers should be an object with ETag and Cache-Control");
     t.assertEquals( "MockedETagPlaceholder", result.headers.ETag, "result.headers should be an object with ETag and Cache-Control");
     t.assertTrue(result.headers.ETag.length > 0, "result.headers should be an object with ETag and Cache-Control");
-    t.assertEquals(DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 };
 exports.testGet_DEV_path_option_FullDefaultResponse = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_DEV_path_option_FullDefaultResponse:\n");
     doMocks({isDev: true}, verbose);
 
     const result = lib.get({path: '/assets/asset-test-target.txt'});
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/assets/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -518,11 +455,14 @@ exports.testGet_DEV_path_option_FullDefaultResponse = () => {
     t.assertEquals('object', typeof result.headers, "result.headers should be an object with ETag and Cache-Control");
     t.assertEquals( "MockedETagPlaceholder", result.headers.ETag, "result.headers should be an object with ETag and Cache-Control");
     t.assertTrue(result.headers.ETag.length > 0, "result.headers should be an object with ETag and Cache-Control");
-    t.assertEquals(DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 };
 
 exports.testGet_contentType_HTML = () => {
-                                                                                                                        if (verbose) log.info("\n\n\ntestGet_path_HTML_FullDefaultResponse:\n");
+    //const verbose = true;
+                                                                                                                        if (verbose) log.info("\n\n\ntestGet_contentType_HTML:\n");
     doMocks({
             io: {
                 mimeType: "text/html"
@@ -531,18 +471,20 @@ exports.testGet_contentType_HTML = () => {
         verbose);
 
     const result = lib.get('/assets/asset-test-target.html');
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
 
     t.assertEquals('string', typeof result.contentType, "Expected string contentType containing 'text/html'");
     t.assertTrue(result.contentType.indexOf("text/html") !== -1, "Expected string contentType containing 'text/html'");
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 }
 
 
 // .get problem/error handling:
 
 exports.testGet_path_noExist_shouldOnly404 = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_path_noExist_shouldOnly404:\n");
     doMocks({
             io: {
@@ -553,16 +495,18 @@ exports.testGet_path_noExist_shouldOnly404 = () => {
 
     const result = lib.get('/assets/asset-test-target.txt');
 
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(404, result.status, "result.status");
 
     t.assertEquals(undefined, result.body, "result.body");
     t.assertEquals(undefined, result.contentType, "result.contentType");
     t.assertEquals(undefined, result.headers, "result.headers");
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 };
 
 exports.testGet_DEV_path_noExist_should404withInfo = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_DEV_path_noExist_should404withInfo:\n");
     doMocks({
             isDev: true,
@@ -573,7 +517,7 @@ exports.testGet_DEV_path_noExist_should404withInfo = () => {
         verbose);
 
     const result = lib.get('/assets/asset-test-target.txt');
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(404, result.status, "result.status");
     t.assertEquals('string', typeof result.body, "Expected string body containing path in dev");
@@ -583,9 +527,12 @@ exports.testGet_DEV_path_noExist_should404withInfo = () => {
     t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "Expected string contentType containing 'text/plain' in dev");
 
     t.assertEquals(undefined, result.headers, "result.headers");
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 };
 
 exports.testGet_path_empty_shouldOnly400 = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_path_empty_shouldOnly400:\n");
     doMocks({
             options: {
@@ -595,17 +542,20 @@ exports.testGet_path_empty_shouldOnly400 = () => {
         verbose);
 
     const result = lib.get();
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(400, result.status, "result.status");
 
     t.assertEquals(undefined, result.body, "result.body");
     t.assertEquals(undefined, result.contentType, "result.contentType");
     t.assertEquals(undefined, result.headers, "result.headers");
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 }
 
 
 exports.testGet_DEV_path_empty_should400WithInfo = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_DEV_path_empty_should400WithInfo:\n");
     doMocks({
             isDev: true,
@@ -616,7 +566,7 @@ exports.testGet_DEV_path_empty_should400WithInfo = () => {
         verbose);
 
     const result = lib.get();
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(400, result.status, "result.status");
 
@@ -626,44 +576,50 @@ exports.testGet_DEV_path_empty_should400WithInfo = () => {
     t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "Expected string contentType containing 'text/plain' in dev");
 
     t.assertEquals(undefined, result.headers, "result.headers");
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 }
 // No need to test for path:spaces too - pathAndOptionsParser is trusted to trim the path.
 
 
 exports.testGet_path_slash_shouldOnly400 = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_path_slash_shouldOnly400:\n");
     doMocks({
         },
         verbose);
 
     const result = lib.get('/');
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(400, result.status, "result.status");
 
     t.assertEquals(undefined, result.body, "result.body");
     t.assertEquals(undefined, result.contentType, "result.contentType");
     t.assertEquals(undefined, result.headers, "result.headers");
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 }
 
 exports.testGet_path_slashes_shouldOnly400 = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_path_slashes_shouldOnly400:\n");
     doMocks({
         },
         verbose);
 
     const result = lib.get('///');
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(400, result.status, "result.status");
 
     t.assertEquals(undefined, result.body, "result.body");
     t.assertEquals(undefined, result.contentType, "result.contentType");
     t.assertEquals(undefined, result.headers, "result.headers");
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 }
 
 
 exports.testGet_DEV_path_slash_should400WithInfo = () => {
+    const verbpse = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_DEV_path_slash_should400WithInfo:\n");
     doMocks({
             isDev: true
@@ -671,7 +627,7 @@ exports.testGet_DEV_path_slash_should400WithInfo = () => {
         verbose);
 
     const result = lib.get('/');
-    if (verbose) log.info(prettify(result, "result"));
+    if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(400, result.status, "result.status");
 
@@ -681,9 +637,11 @@ exports.testGet_DEV_path_slash_should400WithInfo = () => {
     t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "Expected string contentType containing 'text/plain' in dev");
 
     t.assertEquals(undefined, result.headers, "result.headers");
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 }
 
 exports.testGet_DEV_path_slashes_should400WithInfo = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_DEV_path_slashes_should400WithInfo:\n");
     doMocks({
             isDev: true
@@ -691,7 +649,7 @@ exports.testGet_DEV_path_slashes_should400WithInfo = () => {
         verbose);
 
     const result = lib.get('///');
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(400, result.status, "result.status");
 
@@ -701,6 +659,7 @@ exports.testGet_DEV_path_slashes_should400WithInfo = () => {
     t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "Expected string contentType containing 'text/plain' in dev");
 
     t.assertEquals(undefined, result.headers, "result.headers");
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 }
 
 
@@ -717,7 +676,7 @@ exports.testGet_optionParsingError_should500withErrorId = () => {
         verbose);
 
     const result = lib.get("my/path");
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(500, result.status, "result.status");
 
@@ -742,7 +701,7 @@ exports.testGet_contentTypeFuncError_should500withErrorId = () => {
         verbose);
 
     const result = lib.get("my/path");
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(500, result.status, "result.status");
 
@@ -767,7 +726,7 @@ exports.testGet_cacheControlFuncError_should500withErrorId = () => {
         verbose);
 
     const result = lib.get("my/path");
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(500, result.status, "result.status");
 
@@ -800,7 +759,7 @@ exports.testGet_optionParsing_throwErrors_shouldThrowError = () => {
         result = lib.get("my/path");
         failed = false;
     } catch (e) {
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
                                                                                                                         if (verbose) log.error(e);
     }
 
@@ -827,7 +786,7 @@ exports.testGet_contentTypeFunc_throwErrors_shouldThrowError = () => {
         result = lib.get("my/path");
         failed = false;
     } catch (e) {
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
                                                                                                                         if (verbose) log.error(e);
     }
 
@@ -854,7 +813,7 @@ exports.testGet_cacheControlFunc_throwErrors_shouldThrowError = () => {
         result = lib.get("my/path");
         failed = false;
     } catch (e) {
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
                                                                                                                         if (verbose) log.error(e);
     }
 
@@ -862,1007 +821,3 @@ exports.testGet_cacheControlFunc_throwErrors_shouldThrowError = () => {
     t.assertEquals(undefined, result, "result");
     log.info("OK.");
 }
-
-
-
-
-
-
-
-//////////////////////////////////////////////////////////////////////  TEST .buildGetter
-
-/*
-exports.testStatic_fail_missingRoot_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter();
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-exports.testStatic_fail_missingRoot_shouldThrowErrorEvenOnFalseThrowerrorsOption = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter({throwErrors: false});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-exports.testStatic_fail_emptyRoot_argRoot_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter('');
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-exports.testStatic_fail_emptyRoot_argOption_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter({root: ''});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-exports.testStatic_fail_emptyRoot_argOption_shouldThrowErrorEvenOnFalseThrowerrorsOption = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter({root: '', throwErrors: false});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-exports.testStatic_fail_spacesRoot_argRoot_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter('  ');
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-exports.testStatic_fail_spacesRoot_argOption_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter({root: '  '});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-exports.testStatic_fail_illegalCharRoot_argRoot_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter('illegal:path');
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-exports.testStatic_fail_illegalCharRoot_argOption_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter({root: 'illegal:path'});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-exports.testStatic_fail_illegalDoubleDotRoot_argRoot_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter('illegal/../path');
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-exports.testStatic_fail_illegalDoubleDotRoot_argOption_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter({root: 'illegal/../path'});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-exports.testStatic_fail_illegalSlashRoot_argRoot_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter('/');
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-exports.testStatic_fail_illegalSlashRoot_argOption_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter({root: '/'});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-exports.testStatic_fail_illegalTypeRoot_argRoot_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter(42);
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-exports.testStatic_fail_illegalTypeRoot_argOption_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter({root: 42});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-exports.testStatic_fail_illegalArrayRoot_argRoot_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter(["this", "is", "no", "good"]);
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-exports.testStatic_fail_illegalZeroRoot_argOption_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter({root: 0});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-
-exports.testStatic_fail_optionParsingError_arg2_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter('assets', {etag: ["not", "valid"]});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-exports.testStatic_fail_optionParsingError_arg2_shouldThrowErrorEvenWithThrowErrorsFalse = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter('assets', {etag: ["not", "valid"], throwErrors: false});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-exports.testStatic_fail_optionParsingError_arg1_shouldThrowError = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter({root: 'assets', etag: ["not", "valid"]});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-exports.testStatic_fail_optionParsingError_arg1_shouldThrowErrorEvenWithThrowErrorsFalse = () => {
-    const lib = require('./index');
-
-    let getStatic, failed = true;
-    try {
-        getStatic = lib.buildGetter({root: 'assets', etag: ["not", "valid"], throwErrors: false});
-        failed = false;
-    } catch (e) {
-        log.info("Ok - errorMessage as expected: " + e.message);
-    }
-    t.assertTrue(failed, "Should have failed");
-    t.assertTrue(!getStatic, "Should not have produced a getStatic function");
-}
-
-
-//////////////////////////////////////////////////////////////////////////////////  Test the returned getStatic func
-
-exports.testGetStatic_root_Asset_FullDefaultResponse = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets');            // Root folder: '/assets/'
-
-    // Simulate an XP GET request from frontend
-    const request = {
-        rawPath: 'my/endpoint/asset-test-target.txt',              // This path, in context of contextPath, yields the relative path 'asset-test-target.txt',
-        contextPath: 'my/endpoint'                              // which together with the root folder 'assets' becomes the full asset path: 'assets/asset-test-target.txt'
-    };
-
-    const result = getStatic(request);
-
-    t.assertEquals("I am a test asset\n", ioLib.readText(result.body));
-    t.assertEquals(200, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-
-    t.assertTrue(!!result.headers);
-    t.assertEquals('object', typeof result.headers);
-    t.assertEquals('string', typeof result.headers.ETag);
-    t.assertTrue(result.headers.ETag.length > 0);
-    t.assertEquals(optionsParser.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"]);
-
-    log.info(".buildGetter example: full get response readout, body is a resource object (" +
-        (typeof result + (result && typeof result === 'object' ? (" with keys: " + JSON.stringify(Object.keys(result))) : "")
-        ) + "): " + JSON.stringify(result, null, 2)
-    );
-};
-
-
-exports.testGetStatic_optionsRoot = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter({root: 'assets'});            // Root folder: '/assets/'
-
-    // Simulate an XP GET request from frontend
-    const request = {
-        rawPath: 'my/endpoint/asset-test-target.txt',              // This path, in context of contextPath, yields the relative path 'asset-test-target.txt',
-        contextPath: 'my/endpoint'                              // which together with the root folder 'assets' becomes the full asset path: 'assets/asset-test-target.txt'
-    };
-
-    const result = getStatic(request);
-
-    t.assertEquals("I am a test asset\n", ioLib.readText(result.body));
-    t.assertEquals(200, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-
-    t.assertTrue(!!result.headers);
-    t.assertEquals('object', typeof result.headers);
-    t.assertEquals('string', typeof result.headers.ETag);
-    t.assertTrue(result.headers.ETag.length > 0);
-    t.assertEquals(optionsParser.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"]);
-};
-
-exports.testGetStatic_ifNoneMatch_matchingEtagValues_should304 = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets');
-
-    const request = {
-        rawPath: 'my/endpoint/asset-test-target.txt',
-        contextPath: 'my/endpoint',
-        headers: {
-            'If-None-Match': 'djsptplmcdcidp39wx6ydiwn3'        // <-- TODO: Copied from output. Should mock instead.
-        }
-    };
-
-    const result = getStatic(request);
-
-    t.assertEquals(304, result.status);
-};
-
-exports.testGetStatic_ifNoneMatch_nonMatchingEtagValues_should200WithUpdatedContentAndEtag = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets');
-
-    const request = {
-        rawPath: 'my/endpoint/asset-test-target.txt',
-        contextPath: 'my/endpoint',
-        headers: {
-            'If-None-Match': 'oldEtagValue87654321'
-        }
-    };
-
-    const result = getStatic(request);
-
-    t.assertEquals("I am a test asset\n", ioLib.readText(result.body));
-    t.assertEquals(200, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-
-    t.assertTrue(!!result.headers);
-    t.assertEquals('object', typeof result.headers);
-    t.assertEquals(optionsParser.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"]);
-    t.assertTrue(!!(result.headers || {}).ETag); // An ETag header should be generated
-    t.assertNotEquals("oldEtagValue87654321", (result.headers || {}).ETag); // a NEW ETag header should be generated
-};
-
-exports.testGetStatic_option_arg2_getCleanPath = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets', {
-        getCleanPath: request =>  request.rawPath.substring('my/endpoint'.length)
-    });
-
-    // Simulate an XP GET request from a frontend that's NOT a prefix that leaves a relative asset path:
-    const request = {
-        rawPath: 'my/endpoint/asset-test-target.txt',               // Uses the getCleanPath option instead of the contextPath, to return the relative path 'asset-test-target.txt',
-        contextPath: 'this/is/ignored'                              // which together with the root folder 'assets' becomes the full asset rawPath: 'assets/asset-test-target.txt'
-    };
-
-    const result = getStatic(request);
-
-    t.assertEquals("I am a test asset\n", ioLib.readText(result.body));
-    t.assertEquals(200, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-};
-
-exports.testGetStatic_option_arg1_getCleanPath = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter({
-        root: 'assets',
-        getCleanPath: request =>  request.rawPath.substring('my/endpoint'.length)
-    });
-
-    // Simulate an XP GET request from a frontend that's NOT a prefix that leaves a relative asset path:
-    const request = {
-        rawPath: 'my/endpoint/asset-test-target.txt',               // Uses the getCleanPath option instead of the contextPath, to return the relative path 'asset-test-target.txt',
-        contextPath: 'this/is/ignored'                              // which together with the root folder 'assets' becomes the full asset rawPath: 'assets/asset-test-target.txt'
-    };
-
-    const result = getStatic(request);
-
-    t.assertEquals("I am a test asset\n", ioLib.readText(result.body));
-    t.assertEquals(200, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-};
-
-
-exports.testGetStatic_HTML_FullDefaultResponse = () => {
-    const lib = require('./index');
-
-
-    const getStatic = lib.buildGetter('static');
-    const request = {
-        rawPath: 'my/endpoint/static-test-html.html',
-        contextPath: 'my/endpoint'
-    };                                                  // --> /static/static-test-html.html
-
-    const result = getStatic(request);
-
-    t.assertEquals("<html><body><p>I am a test HTML</p></body></html>\n", ioLib.readText(result.body));
-    t.assertEquals(200, result.status);
-    t.assertTrue(!!result.contentType);
-    t.assertTrue(result.contentType.indexOf("text/html") !== -1);
-
-    t.assertTrue(!!result.headers);
-    t.assertEquals('object', typeof result.headers);
-    t.assertEquals('string', typeof result.headers.ETag);
-    t.assertTrue(result.headers.ETag.length > 0);
-    t.assertEquals(optionsParser.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"]);
-};
-
-exports.testGetStatic_Css = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('static');
-    const request = {
-        rawPath: 'my/endpoint/static-test-css.css',
-        contextPath: 'my/endpoint'
-    };                                                  // --> /static/static-test-css.css
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.contentType);
-    t.assertTrue(result.contentType.indexOf("text/css") !== -1);
-    t.assertEquals(".i.am.a.test.css {\n\n}\n", ioLib.readText(result.body));
-
-    t.assertTrue(!!result.headers);
-    t.assertEquals('object', typeof result.headers);
-    t.assertEquals('string', typeof result.headers.ETag);
-    t.assertTrue(result.headers.ETag.length > 0);
-    t.assertEquals(optionsParser.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"]);
-};
-
-exports.testGetStatic_JS = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('static');
-    const request = {
-        rawPath: 'my/endpoint/static-test-js.js',
-        contextPath: 'my/endpoint'
-    };                                                  // --> /static/static-test-js.js
-
-    const result = getStatic(request);
-
-
-    t.assertTrue(!!result.contentType);
-    t.assertTrue(result.contentType.indexOf("application/javascript") !== -1);
-    t.assertEquals("console.log(\"I am a test js\");\n", ioLib.readText(result.body));
-
-    t.assertTrue(!!result.headers);
-    t.assertEquals('object', typeof result.headers);
-    t.assertEquals('string', typeof result.headers.ETag);
-    t.assertTrue(result.headers.ETag.length > 0);
-    t.assertEquals(optionsParser.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"]);
-};
-
-exports.testGetStatic_JSON = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('static');
-    const request = {
-        rawPath: 'my/endpoint/static-test-json.json',
-        contextPath: 'my/endpoint'
-    };                                                  // --> /static/static-test-json.json
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.contentType);
-    t.assertTrue(result.contentType.indexOf("application/json") !== -1);
-    t.assertEquals(`{
-  "I": {
-    "am": "a",
-    "test": "json"
-  }
-}
-`, ioLib.readText(result.body));
-
-    t.assertTrue(!!result.headers);
-    t.assertEquals('object', typeof result.headers);
-    t.assertEquals('string', typeof result.headers.ETag);
-    t.assertTrue(result.headers.ETag.length > 0);
-    t.assertEquals(optionsParser.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"]);
-};
-
-exports.testGetStatic_XML = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('static');
-    const request = {
-        rawPath: 'my/endpoint/static-test-xml.xml',
-        contextPath: 'my/endpoint'
-    };                                                  // --> /static/static-test-xml.xml
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.contentType);
-    t.assertTrue(result.contentType.indexOf("text/xml") !== -1);
-    t.assertEquals(`<I>
-    <am>a</am>
-    <test>xml</test>
-</I>
-`, ioLib.readText(result.body));
-
-    t.assertTrue(!!result.headers);
-    t.assertEquals('object', typeof result.headers);
-    t.assertEquals('string', typeof result.headers.ETag);
-    t.assertTrue(result.headers.ETag.length > 0);
-    t.assertEquals(optionsParser.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"]);
-}
-
-exports.testGetStatic_Text = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('static');
-    const request = {
-        rawPath: 'my/endpoint/static-test-text.txt',
-        contextPath: 'my/endpoint'
-    };                                                  // --> /static/static-test-text.txt
-
-    const result = getStatic(request);
-
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertEquals("I am a test text\n", ioLib.readText(result.body));
-
-    t.assertTrue(!!result.headers);
-    t.assertEquals('object', typeof result.headers);
-    t.assertEquals('string', typeof result.headers.ETag);
-    t.assertTrue(result.headers.ETag.length > 0);
-    t.assertEquals(optionsParser.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"]);
-}
-
-exports.testGetStatic_JPG = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('static');
-    const request = {
-        rawPath: 'my/endpoint/w3c_home.jpg',
-        contextPath: 'my/endpoint'
-    };                                                  // --> /static/w3c_home.jpg
-
-    const result = getStatic(request);
-
-    t.assertEquals(200, result.status);
-    t.assertTrue(!!result.contentType);
-    t.assertTrue(result.contentType.indexOf("image/jpeg") !== -1);
-
-    t.assertTrue(!!result.headers);
-    t.assertEquals('object', typeof result.headers);
-    t.assertEquals('string', typeof result.headers.ETag);
-    t.assertTrue(result.headers.ETag.length > 0);
-    t.assertEquals(optionsParser.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"]);
-};
-
-exports.testGetStatic_GIF = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('static');
-    const request = {
-        rawPath: 'my/endpoint/w3c_home.gif',
-        contextPath: 'my/endpoint'
-    };                                                  // --> /static/w3c_home.gif
-
-    const result = getStatic(request);
-
-    t.assertEquals(200, result.status);
-    t.assertTrue(!!result.contentType);
-    t.assertTrue(result.contentType.indexOf("image/gif") !== -1);
-
-    t.assertTrue(!!result.headers);
-    t.assertEquals('object', typeof result.headers);
-    t.assertEquals('string', typeof result.headers.ETag);
-    t.assertTrue(result.headers.ETag.length > 0);
-    t.assertEquals(optionsParser.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"]);
-};
-
-
-/////////////  Test getStatic errorHandling
-
-
-exports.testGetStatic_fail_rootArg_NotFoundFile_should404 = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('static');
-    const request = {
-        rawPath: 'my/endpoint/doesNotExist.txt',
-        contextPath: 'my/endpoint'
-    };                                                  // --> /static/doesNotExist.txt
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body);
-    t.assertEquals(404, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']); // No cache-control header should be generated
-    t.assertTrue(!(result.headers || {}).ETag); // No ETag header should be generated
-
-    log.info(`OK: ${result.status} - ${result.body}`);
-}
-exports.testGetStatic_fail_optionsArg_NotFoundFile_should404 = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter({root: 'static'});              // Same as above, just root as named parameter
-    const request = {
-        rawPath: 'my/endpoint/doesNotExist.txt',
-        contextPath: 'my/endpoint'
-    };
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body);
-    t.assertEquals(404, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']);
-    t.assertTrue(!(result.headers || {}).ETag);
-
-    log.info(`OK: ${result.status} - ${result.body}`);
-}
-exports.testGetStatic_fail_NotFoundInRoot_should404 = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets');
-    const request = {
-        rawPath: 'my/endpoint/static-test-text.txt',
-        contextPath: 'my/endpoint'
-    };                                                  // --> /assets/static-test-text.txt does not exist
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body);
-    t.assertEquals(404, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']); // No cache-control header should be generated
-    t.assertTrue(!(result.headers || {}).ETag); // No ETag header should be generated
-
-    log.info(`OK: ${result.status} - ${result.body}`);
-}
-
-exports.testGetStatic_fail_empty_should400 = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets');
-    const request = {
-        rawPath: 'my/endpoint',                                // --> /assets/ yields empty relative path
-        contextPath: 'my/endpoint'
-    };
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body);
-    t.assertEquals(400, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']); // No cache-control header should be generated
-    t.assertTrue(!(result.headers || {}).ETag); // No ETag header should be generated
-
-    log.info(`OK: ${result.status} - ${result.body}`)
-}
-
-exports.testGetStatic_fail_slash_should400 = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets');
-    const request = {
-        rawPath: 'my/endpoint/',                                // --> yields relative path '/'
-        contextPath: 'my/endpoint'
-    };
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body);
-    t.assertEquals(400, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']); // No cache-control header should be generated
-    t.assertTrue(!(result.headers || {}).ETag); // No ETag header should be generated
-
-    log.info(`OK: ${result.status} - ${result.body}`)
-}
-exports.testGetStatic_fail_slashes_should400 = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets');
-    const request = {
-        rawPath: 'my/endpoint///',                                // --> yields relative path '///', counts as empty
-        contextPath: 'my/endpoint'
-    };
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body);
-    t.assertEquals(400, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']); // No cache-control header should be generated
-    t.assertTrue(!(result.headers || {}).ETag); // No ETag header should be generated
-
-    log.info(`OK: ${result.status} - ${result.body}`)
-}
-exports.testGetStatic_fail_illegalChars_should400 = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets');
-    const request = {
-        rawPath: 'my/endpoint/the_characters>and<are_no_good',
-        contextPath: 'my/endpoint'
-    };
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body);
-    t.assertEquals(400, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']);
-    t.assertTrue(!(result.headers || {}).ETag);
-
-    log.info(`OK: ${result.status} - ${result.body}`)
-}
-exports.testGetStatic_fail_illegalDoubledots_should400 = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets');
-    const request = {
-        rawPath: 'my/endpoint/trying/to/../hack/this',
-        contextPath: 'my/endpoint'
-    };
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body);
-    t.assertEquals(400, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']);
-    t.assertTrue(!(result.headers || {}).ETag);
-
-    log.info(`OK: ${result.status} - ${result.body}`)
-}
-exports.testGetStatic_fail_illegalWildcards_should400 = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets');
-    const request = {
-        rawPath: 'my/endpoint/trying/to/???/hack/*.this',
-        contextPath: 'my/endpoint'
-    };
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body, "Should have returned a body in dev mode. Result: " + JSON.stringify(result));
-    t.assertEquals(400, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']);
-    t.assertTrue(!(result.headers || {}).ETag);
-
-    log.info(`OK: ${result.status} - ${result.body}`)
-}
-exports.testGetStatic_fail_pathNotUnderContextPath_should500 = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets');
-    const request = {
-        rawPath: 'another/endpoint/trying/to/???/hack/*.this',
-        contextPath: 'my/endpoint'
-    };
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body);
-    t.assertEquals(500, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']);
-    t.assertTrue(!(result.headers || {}).ETag);
-
-    log.info(`OK: ${result.status} - ${result.body}`)
-}
-
-
-exports.testGetStatic_fail_contentTypeFunc_runtimeError_should500withMessage = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets', {
-        contentType: () => {
-            throw Error("This will be thrown outside of parsePathAndFunctions. Should still be handled.");
-        }
-    });
-
-    const request = {
-        rawPath: 'my/endpoint/asset-test-target.txt',
-        contextPath: 'my/endpoint'
-    };
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body);
-    t.assertEquals(500, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']); // No cache-control header should be generated
-    t.assertTrue(!(result.headers || {}).ETag); // No ETag header should be generated
-
-    log.info(`OK: ${result.status} - ${result.body}`)
-}
-exports.testGetStatic_fail_contentTypeFunc_runtimeError_throwErrors = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets', {
-        contentType: () => {
-            throw Error("This will be thrown outside of parsePathAndFunctions. Should still be handled.");
-        },
-        throwErrors: true
-    });
-
-    const request = {
-        rawPath: 'my/endpoint/asset-test-target.txt',
-        contextPath: 'my/endpoint'
-    };
-
-    let result = null,
-        failed = true;
-    try {
-        result = getStatic(request);
-        failed = false;
-
-    } catch (e) {
-        log.info("OK: " + e.message);
-    }
-
-    t.assertTrue(failed, "Should have failed. Instead, got a result: " + JSON.stringify(result));
-}
-
-
-exports.testGetStatic_fail_cacheControlFunc_runtimeError_should500withMessage = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets', {
-        cacheControl: () => {
-            throw Error("This will be thrown outside of parsePathAndFunctions. Should still be handled.");
-        }
-    });
-
-    const request = {
-        rawPath: 'my/endpoint/asset-test-target.txt',
-        contextPath: 'my/endpoint'
-    };
-
-    const result = getStatic(request);
-
-    t.assertTrue(!!result.body);
-    t.assertEquals(500, result.status);
-    t.assertTrue(typeof result.contentType === 'string');
-    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "result.contentType should contain 'text/plain'");
-    t.assertTrue(!(result.headers || {})['Cache-Control']); // No cache-control header should be generated
-    t.assertTrue(!(result.headers || {}).ETag); // No ETag header should be generated
-
-    log.info(`OK: ${result.status} - ${result.body}`)
-}
-exports.testGetStatic_fail_cacheControlFunc_runtimeError_throwErrors = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter('assets', {
-        cacheControl: () => {
-            throw Error("This will be thrown outside of parsePathAndFunctions. Should still be handled.");
-        },
-        throwErrors: true
-    });
-
-    const request = {
-        rawPath: 'my/endpoint/asset-test-target.txt',
-        contextPath: 'my/endpoint'
-    };
-
-    let result = null,
-        failed = true;
-    try {
-        result = getStatic(request);
-        failed = false;
-
-    } catch (e) {
-        log.info("OK: " + e.message);
-    }
-
-    t.assertTrue(failed, "Should have failed. Instead, got a result: " + JSON.stringify(result));
-}
-
-
-// Verify that a even if the getStatic function fails once, it will keep working for new requests later
-exports.testGetStatic_fail_failuresShouldNotDestroyGetstaticFunction = () => {
-    const lib = require('./index');
-
-    const getStatic = lib.buildGetter({
-        root: 'static',
-        getCleanPath: req => req.rawPath.substring('my/endpoint'.length)
-    });
-
-    let result;
-
-    result = getStatic({rawPath: 'my/endpoint/static-test-text.txt'});                // <-- This and many below are fine, those should keep working on the same path
-    t.assertEquals(200, result.status, "Expected 200 OK. Result: " + JSON.stringify(result));
-
-    result = getStatic({rawPath: 'my/endpoint/bad<character'});
-    t.assertTrue(result.status >= 400, "Expected a failing getStatic call: illegal char '<'. Result: " + JSON.stringify(result));
-    log.info(`OK: ${result.status} - ${result.body}`);
-
-    result = getStatic({rawPath: 'my/endpoint/static-test-css.css'});
-    t.assertEquals(200, result.status, "Expected 200 OK. Result: " + JSON.stringify(result));
-
-    result = getStatic({rawPath: 'my/endpoint/static-test-json.json'});
-    t.assertEquals(200, result.status, "Expected 200 OK. Result: " + JSON.stringify(result));
-
-    result = getStatic({rawPath: 'my/endpoint/bad>character'});
-    t.assertTrue(result.status >= 400, "Expected a failing getStatic call: illegal char '>'. Result: " + JSON.stringify(result));
-    log.info(`OK: ${result.status} - ${result.body}`);
-
-    result = getStatic({rawPath: 'my/endpoint/bad/../characters'});
-    t.assertTrue(result.status >= 400, "Expected a failing getStatic call: illegal chars '..'. Result: " + JSON.stringify(result));
-    log.info(`OK: ${result.status} - ${result.body}`);
-
-    result = getStatic({rawPath: 'my/endpoint/w3c_home.gif'});
-    t.assertEquals(200, result.status, "Expected 200 OK. Result: " + JSON.stringify(result));
-
-    result = getStatic({rawPath: 'my/endpoint/w3c_no_exist.gif'});
-    t.assertTrue(result.status >= 400, "Expected a failing getStatic call: not exist. Result: " + JSON.stringify(result));
-    log.info(`OK: ${result.status} - ${result.body}`);
-
-    result = getStatic({rawPath: 'my/endpoint/w3c_home.gif'});
-    t.assertEquals(200, result.status, "Expected 200 OK. Result: " + JSON.stringify(result));
-
-    result = getStatic({rawPath: 'my/endpoint/'});
-    t.assertTrue(result.status >= 400, "Expected a failing getStatic call: missing path. Result: " + JSON.stringify(result));
-    log.info(`OK: ${result.status} - ${result.body}`);
-
-    result = getStatic({rawPath: 'my/endpoint/w3c_home.jpg'});
-    t.assertEquals(200, result.status, "Expected 200 OK. Result: " + JSON.stringify(result));
-
-    result = getStatic({rawPath: 'why/is/this/here'});
-    t.assertTrue(result.status >= 400, "Expected a failing getStatic call: path not under contextPath. Result: " + JSON.stringify(result));
-    log.info(`OK: ${result.status} - ${result.body}`);
-
-}
-//*/

--- a/src/test/resources/lib/enonic/static/getPathError-test.es6
+++ b/src/test/resources/lib/enonic/static/getPathError-test.es6
@@ -1,5 +1,4 @@
-const DEFAULT_CACHE_CONTROL = require('/lib/enonic/static/options').DEFAULT_CACHE_CONTROL;
-
+const constants = require('/lib/enonic/static/constants');
 const ioMock = require('/lib/enonic/static/ioMock');
 
 const __getPathError__ = require('./index').__getPathError__;
@@ -37,79 +36,6 @@ mockOptionsparser();
 
 //////////////////////////////////////////////////////////////////  HELPERS
 
-                                                                                                                        const prettify = (obj, label, suppressCode= false, indent = 0) => {
-                                                                                                                            let str = " ".repeat(indent) + (
-                                                                                                                                label !== undefined
-                                                                                                                                    ? label + ": "
-                                                                                                                                    : ""
-                                                                                                                            );
-
-                                                                                                                            if (typeof obj === 'function') {
-                                                                                                                                if (!suppressCode) {
-                                                                                                                                    return `${str}···· (function)\n${" ".repeat(indent + 4)}` +
-                                                                                                                                        obj.toString()
-                                                                                                                                            .replace(
-                                                                                                                                                /\r?\n\r?/g,
-                                                                                                                                                `\n${" ".repeat(indent + 4)}`
-                                                                                                                                            ) +
-                                                                                                                                        "\n" + " ".repeat(indent) + "····"
-                                                                                                                                        ;
-                                                                                                                                } else {
-                                                                                                                                    return `${str}···· (function)`;
-                                                                                                                                }
-
-                                                                                                                            } else if (Array.isArray(obj)) {
-                                                                                                                                return obj.length === 0
-                                                                                                                                    ? `${str}[]`
-                                                                                                                                    : (
-                                                                                                                                        `${str}[\n` +
-                                                                                                                                        obj.map(
-                                                                                                                                            (item, i) =>
-                                                                                                                                                prettify(item, i, suppressCode, indent + 4)
-                                                                                                                                        )
-                                                                                                                                            .join(",\n") +
-                                                                                                                                        `\n${" ".repeat(indent)}]`
-                                                                                                                                    );
-
-                                                                                                                            } else if (obj && typeof obj === 'object') {
-                                                                                                                                try {
-                                                                                                                                    if (Object.keys(obj).length === 0) {
-                                                                                                                                        return `${str}{}`;
-                                                                                                                                    } else {
-                                                                                                                                        return `${str}{\n` +
-                                                                                                                                            Object.keys(obj).map(
-                                                                                                                                                key => prettify(obj[key], key, suppressCode, indent + 4)
-                                                                                                                                            ).join(",\n") +
-                                                                                                                                            `\n${" ".repeat(indent)}}`
-                                                                                                                                    }
-                                                                                                                                } catch (e) {
-                                                                                                                                    log.info(e);
-                                                                                                                                    return `${str}···· (${typeof obj})\n${" ".repeat(indent + 4)}` +
-                                                                                                                                        obj.toString()
-                                                                                                                                            .replace(
-                                                                                                                                                /\r?\n\r?/g,
-                                                                                                                                                `\n${" ".repeat(indent + 4)}`
-                                                                                                                                            ) +
-                                                                                                                                        "\n" + " ".repeat(indent) + `····`;
-                                                                                                                                }
-                                                                                                                            } else if (obj === undefined || obj === null) {
-                                                                                                                                return `${str}${obj}`;
-                                                                                                                            } else if (JSON.stringify(obj) !== undefined) {
-                                                                                                                                return `${str}` + JSON.stringify(obj, null, 2).replace(
-                                                                                                                                    /\r?\n\r?/g,
-                                                                                                                                    `\n${" ".repeat(indent + 2)}`
-                                                                                                                                );
-                                                                                                                            } else {
-                                                                                                                                return `${str}···· (${typeof obj})\n${" ".repeat(indent + 4)}` +
-                                                                                                                                    obj.toString()
-                                                                                                                                        .replace(
-                                                                                                                                            /\r?\n\r?/g,
-                                                                                                                                            `\n${" ".repeat(indent + 4)}`
-                                                                                                                                        ) +
-                                                                                                                                    "\n" + " ".repeat(indent) + `····`;
-                                                                                                                            }
-                                                                                                                        };
-
 /* Mocks runMode.js, io.js, etagReader.js and options.js.
   Optional params: {
     isDev: boolean,
@@ -143,11 +69,11 @@ mockOptionsparser();
     }
  */
 const doMocks = (params={}, verbose= false) => {
-                                                                                                                        if (verbose) log.info(prettify(params, "--- Mocking with params"));
+                                                                                                                        if (verbose) log.info("--- Mocking with params: " + JSON.stringify(params, null, 2));
 
     mockedRunmodeFuncs.isDev = (typeof params.isDev === 'boolean' )
         ? () => {
-                                                                                                                        if (verbose) log.info(prettify(params.isDev, "Mocked isDev"));
+                                                                                                                        if (verbose) log.info("Mocked isDev: " + JSON.stringify(params.isDev, null, 2));
             return params.isDev
         }
         : () => false;
@@ -172,25 +98,25 @@ const doMocks = (params={}, verbose= false) => {
 
             const res = ioMock.getResource(data.path, data.exists, data.content);
 
-                                                                                                                        if (verbose) log.info(prettify(data, "Mocked io.getResource(" + JSON.stringify(path) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked io.getResource(" + JSON.stringify(path) + "): " + JSON.stringify(data, null, 2));
             return res;
         }
     );
     mockedIoFuncs.readText = io.readText || (
         (stream) => {
             const text = io.text || ioMock.readText(stream);
-                                                                                                                        if (verbose) log.info(prettify(text,"Mocked io.readText(stream)"));
+                                                                                                                        if (verbose) log.info("Mocked io.readText(stream): " + JSON.stringify(text, null, 2));
             return text;
         }
     );
     mockedIoFuncs.getMimeType = io.getMimeType || (
         (name) => {
             const mimeType = io.mimeType || ioMock.getMimeType(name);
-                                                                                                                        if (verbose) log.info(prettify(mimeType, "Mocked io.getMimeType(" + JSON.stringify(name) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked io.getMimeType(" + JSON.stringify(name) + "): " + JSON.stringify(mimeType, null, 2));
             return mimeType;
         }
     );
-    if (verbose) log.info(prettify(mockedIoFuncs, "mockedIoFuncs"));
+    if (verbose) log.info("mockedIoFuncs: " + JSON.stringify(mockedIoFuncs, null, 2));
     mockIo();
 
 
@@ -199,7 +125,7 @@ const doMocks = (params={}, verbose= false) => {
     mockedEtagreaderFuncs.read = etagReader.read || (
         (path, etagOverride) => {
             const etag = etagReader.etag || "MockedETagPlaceholder";
-                                                                                                                        if (verbose) log.info(prettify(etag, "Mocked etagReader.read(" + JSON.stringify({path, etagOverride}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked etagReader.read(" + JSON.stringify({path, etagOverride}) + "): " + JSON.stringify(etag, null, 2));
             return etag;
         }
     );
@@ -214,14 +140,14 @@ const doMocks = (params={}, verbose= false) => {
             : ioMock.getMimeType,
         cacheControlFunc: (optionParams.cacheControl !== undefined)
             ? () => optionParams.cacheControl
-            : () => DEFAULT_CACHE_CONTROL
+            : () => constants.DEFAULT_CACHE_CONTROL
     };
     mockedOptionsparserFuncs.parsePathAndOptions = optionParams.parsePathAndOptions || (
         (pathOrOptions, options) => {
             const parsed = (typeof pathOrOptions === 'string')
                 ? { path: pathOrOptions, ...defaultOptions, ...options, ...optionParams }
                 : { ...defaultOptions, ...pathOrOptions, ...optionParams };
-                                                                                                                        if (verbose) log.info(prettify(parsed, "Mocked parseRootAndOptions(" + JSON.stringify({pathOrOptions, options}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked parseRootAndOptions(" + JSON.stringify({pathOrOptions, options}) + "): " + JSON.stringify(parsed, null, 2));
             return parsed;
         }
     );
@@ -230,7 +156,7 @@ const doMocks = (params={}, verbose= false) => {
             const parsed = (typeof rootOrOptions === 'string')
                 ? { root: rootOrOptions, ...defaultOptions, ...options, ...optionParams }
                 : { ...defaultOptions, ...rootOrOptions, ...optionParams };
-                                                                                                                        if (verbose) log.info(prettify(parsed, "Mocked parseRootAndOptions(" + JSON.stringify({rootOrOptions, options}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked parseRootAndOptions(" + JSON.stringify({rootOrOptions, options}) + "): " + JSON.stringify(parsed, null, 2));
             return parsed;
         }
     );
@@ -281,7 +207,7 @@ exports.testGet_innerbehaviour_getPathError_stringArg_isCalled = () => {
     const result = lib.get("my/unique/testing/path");
 
     t.assertEquals("my/unique/testing/path", target);
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 }
 
 
@@ -301,13 +227,14 @@ exports.testGet_innerbehaviour_getPathError_optionArg_isCalled = () => {
     }
 
     const result = lib.get({path: "another/unique/testing/path"});
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
     t.assertEquals("another/unique/testing/path", target);
 
 }
 
 
 exports.testGet_innerbehaviour_getPathError_isUsed = () => {
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGet_innerbehaviour_getPathError_isUsed:\n");
 
     doMocks({
@@ -321,10 +248,11 @@ exports.testGet_innerbehaviour_getPathError_isUsed = () => {
     }
 
     const result = lib.get({path: "yet/another/unique/testing/path"});
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(400, result.status, "result.status");
     log.info("OK")
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 }
 
 

--- a/src/test/resources/lib/enonic/static/options-test.es6
+++ b/src/test/resources/lib/enonic/static/options-test.es6
@@ -1,4 +1,5 @@
 const ioLib = require('/lib/enonic/static/io');
+const constants = require('/lib/enonic/static/constants');
 
 const lib = require('/lib/enonic/static/options');
 const t = require('/lib/xp/testing');
@@ -7,7 +8,7 @@ const t = require('/lib/xp/testing');
 ////////////////////////////////////////////////////////////////// Helpers
 
 // Turning the strings to regex patterns
-const DEFAULT_CACHE_CONTROL_PATTERNS = lib.DEFAULT_CACHE_CONTROL_FIELDS.map(item => {
+const DEFAULT_CACHE_CONTROL_PATTERNS = constants.DEFAULT_CACHE_CONTROL_FIELDS.map(item => {
     const replacedItem = item
         .replace(/\s*([=])\s*/g,"\\s*$1\\s*");
     return new RegExp("(" +
@@ -32,7 +33,7 @@ const assertCacheControlIsDefault = (cacheControl) => {
     DEFAULT_CACHE_CONTROL_PATTERNS.forEach((pattern, i) => {
         t.assertTrue(
             !!cacheControl.match(pattern),
-            "Couldn't find the expected item '" + lib.DEFAULT_CACHE_CONTROL_FIELDS[i] + "' in the produced 'Cache-Control' header value: " + JSON.stringify(cacheControl) + ". Should be something like " + JSON.stringify(lib.DEFAULT_CACHE_CONTROL));
+            "Couldn't find the expected item '" + constants.DEFAULT_CACHE_CONTROL_FIELDS[i] + "' in the produced 'Cache-Control' header value: " + JSON.stringify(cacheControl) + ". Should be something like " + JSON.stringify(constants.DEFAULT_CACHE_CONTROL));
     });
 
     // Verify: find only the default headers
@@ -44,7 +45,7 @@ const assertCacheControlIsDefault = (cacheControl) => {
                 DEFAULT_CACHE_CONTROL_PATTERNS.forEach(ccPattern => {
                     ccFound = ccFound || ccHeader.match(ccPattern);
                 });
-                t.assertTrue(ccFound, "Unexpected item '" + ccHeader + "' found in the produced 'Cache-Control' header value: " + JSON.stringify(cacheControl)  + ". Should be something like " + JSON.stringify(lib.DEFAULT_CACHE_CONTROL));
+                t.assertTrue(ccFound, "Unexpected item '" + ccHeader + "' found in the produced 'Cache-Control' header value: " + JSON.stringify(cacheControl)  + ". Should be something like " + JSON.stringify(constants.DEFAULT_CACHE_CONTROL));
             }
         });
 }
@@ -161,10 +162,10 @@ exports.testParsePathAndOptions_path_validStringOnly_producesDefaultMimeDetectin
 exports.testParsePathAndOptions_path_validStringOnly_producesDefaultCacheControlFunction = () => {
     const { cacheControlFunc } = lib.parsePathAndOptions("i/am/a/path.txt");
 
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.txt", "Some random content", "text/plain"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.js", "Some random content", "application/javascript"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.json", "Some random content", "application/javascripton"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.html", "Some random content", "text/html"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.txt", "Some random content", "text/plain"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.js", "Some random content", "application/javascript"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.json", "Some random content", "application/javascripton"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.html", "Some random content", "text/html"));
 }
 
 
@@ -219,10 +220,10 @@ exports.testParsePathAndOptions_optionsWithPath_validObj_producesDefaultMimeDete
 exports.testParsePathAndOptions_optionsWithPath_validObj_producesDefaultCacheControlFunction = () => {
     const { cacheControlFunc } = lib.parsePathAndOptions({path: "i/am/a/path.txt"});
 
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.txt", "Some random content", "text/plain"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.js", "Some random content", "application/javascript"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.json", "Some random content", "application/javascripton"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.html", "Some random content", "text/html"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.txt", "Some random content", "text/plain"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.js", "Some random content", "application/javascript"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.json", "Some random content", "application/javascripton"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.html", "Some random content", "text/html"));
 }
 
 exports.testParsePathAndOptions_path_pathArg_emptyString_passThrough = () => {
@@ -1903,10 +1904,10 @@ exports.testParseRootAndOptions_path_validStringOnly_producesDefaultMimeDetectin
 exports.testParseRootAndOptions_path_validStringOnly_producesDefaultCacheControlFunction = () => {
     const { cacheControlFunc } = lib.parseRootAndOptions("i/am/root");
 
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.txt", "Some random content", "text/plain"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.js", "Some random content", "application/javascript"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.json", "Some random content", "application/javascripton"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.html", "Some random content", "text/html"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.txt", "Some random content", "text/plain"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.js", "Some random content", "application/javascript"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.json", "Some random content", "application/javascripton"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.html", "Some random content", "text/html"));
 }
 
 
@@ -1961,10 +1962,10 @@ exports.testParseRootAndOptions_optionsWithPath_validObj_producesDefaultMimeDete
 exports.testParseRootAndOptions_optionsWithPath_validObj_producesDefaultCacheControlFunction = () => {
     const { cacheControlFunc } = lib.parseRootAndOptions({root: "i/am/root"});
 
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.txt", "Some random content", "text/plain"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.js", "Some random content", "application/javascript"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.json", "Some random content", "application/javascripton"));
-    t.assertEquals(lib.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.html", "Some random content", "text/html"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.txt", "Some random content", "text/plain"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.js", "Some random content", "application/javascript"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.json", "Some random content", "application/javascripton"));
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, cacheControlFunc("i/am/a/path.html", "Some random content", "text/html"));
 }
 
 exports.testParseRootAndOptions_path_pathArg_emptyString_passThrough = () => {

--- a/src/test/resources/lib/enonic/static/resolveRoot-test.es6
+++ b/src/test/resources/lib/enonic/static/resolveRoot-test.es6
@@ -1,5 +1,4 @@
-const DEFAULT_CACHE_CONTROL = require('/lib/enonic/static/options').DEFAULT_CACHE_CONTROL;
-
+const constants = require('/lib/enonic/static/constants');
 const ioMock = require('/lib/enonic/static/ioMock');
 
 const t = require('/lib/xp/testing');
@@ -31,79 +30,6 @@ mockOptionsparser();
 const lib = require('./index');
 
 //////////////////////////////////////////////////////////////////  HELPERS
-
-                                                                                                                        const prettify = (obj, label, suppressCode= false, indent = 0) => {
-                                                                                                                            let str = " ".repeat(indent) + (
-                                                                                                                                label !== undefined
-                                                                                                                                    ? label + ": "
-                                                                                                                                    : ""
-                                                                                                                            );
-
-                                                                                                                            if (typeof obj === 'function') {
-                                                                                                                                if (!suppressCode) {
-                                                                                                                                    return `${str}···· (function)\n${" ".repeat(indent + 4)}` +
-                                                                                                                                        obj.toString()
-                                                                                                                                            .replace(
-                                                                                                                                                /\r?\n\r?/g,
-                                                                                                                                                `\n${" ".repeat(indent + 4)}`
-                                                                                                                                            ) +
-                                                                                                                                        "\n" + " ".repeat(indent) + "····"
-                                                                                                                                        ;
-                                                                                                                                } else {
-                                                                                                                                    return `${str}···· (function)`;
-                                                                                                                                }
-
-                                                                                                                            } else if (Array.isArray(obj)) {
-                                                                                                                                return obj.length === 0
-                                                                                                                                    ? `${str}[]`
-                                                                                                                                    : (
-                                                                                                                                        `${str}[\n` +
-                                                                                                                                        obj.map(
-                                                                                                                                            (item, i) =>
-                                                                                                                                                prettify(item, i, suppressCode, indent + 4)
-                                                                                                                                        )
-                                                                                                                                            .join(",\n") +
-                                                                                                                                        `\n${" ".repeat(indent)}]`
-                                                                                                                                    );
-
-                                                                                                                            } else if (obj && typeof obj === 'object') {
-                                                                                                                                try {
-                                                                                                                                    if (Object.keys(obj).length === 0) {
-                                                                                                                                        return `${str}{}`;
-                                                                                                                                    } else {
-                                                                                                                                        return `${str}{\n` +
-                                                                                                                                            Object.keys(obj).map(
-                                                                                                                                                key => prettify(obj[key], key, suppressCode, indent + 4)
-                                                                                                                                            ).join(",\n") +
-                                                                                                                                            `\n${" ".repeat(indent)}}`
-                                                                                                                                    }
-                                                                                                                                } catch (e) {
-                                                                                                                                    log.info(e);
-                                                                                                                                    return `${str}···· (${typeof obj})\n${" ".repeat(indent + 4)}` +
-                                                                                                                                        obj.toString()
-                                                                                                                                            .replace(
-                                                                                                                                                /\r?\n\r?/g,
-                                                                                                                                                `\n${" ".repeat(indent + 4)}`
-                                                                                                                                            ) +
-                                                                                                                                        "\n" + " ".repeat(indent) + `····`;
-                                                                                                                                }
-                                                                                                                            } else if (obj === undefined || obj === null) {
-                                                                                                                                return `${str}${obj}`;
-                                                                                                                            } else if (JSON.stringify(obj) !== undefined) {
-                                                                                                                                return `${str}` + JSON.stringify(obj, null, 2).replace(
-                                                                                                                                    /\r?\n\r?/g,
-                                                                                                                                    `\n${" ".repeat(indent + 2)}`
-                                                                                                                                );
-                                                                                                                            } else {
-                                                                                                                                return `${str}···· (${typeof obj})\n${" ".repeat(indent + 4)}` +
-                                                                                                                                    obj.toString()
-                                                                                                                                        .replace(
-                                                                                                                                            /\r?\n\r?/g,
-                                                                                                                                            `\n${" ".repeat(indent + 4)}`
-                                                                                                                                        ) +
-                                                                                                                                    "\n" + " ".repeat(indent) + `····`;
-                                                                                                                            }
-                                                                                                                        };
 
 /* Mocks runMode.js, io.js, etagReader.js and options.js.
   Optional params: {
@@ -142,7 +68,7 @@ const doMocks = (params={}, verbose= false) => {
 
     mockedRunmodeFuncs.isDev = (typeof params.isDev === 'boolean' )
         ? () => {
-                                                                                                                        if (verbose) log.info(prettify(params.isDev, "Mocked isDev"));
+                                                                                                                        if (verbose) log.info("Mocked isDev: " + JSON.stringify(params.isDev, null, 2));
             return params.isDev
         }
         : () => false;
@@ -161,21 +87,21 @@ const doMocks = (params={}, verbose= false) => {
 
             const res = ioMock.getResource(data.path, data.exists, data.content);
 
-                                                                                                                        if (verbose) log.info(prettify(data, "Mocked io.getResource(" + JSON.stringify(path) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked io.getResource(" + JSON.stringify(path) + "): " + JSON.stringify(data, null, 2));
             return res;
         }
     );
     mockedIoFuncs.readText = io.readText || (
         (stream) => {
             const text = io.text || ioMock.readText(stream);
-                                                                                                                        if (verbose) log.info(prettify(text,"Mocked io.readText(stream)"));
+                                                                                                                        if (verbose) log.info("Mocked io.readText(stream): " + JSON.stringify(text, null, 2));
             return text;
         }
     );
     mockedIoFuncs.getMimeType = io.getMimeType || (
         (name) => {
             const mimeType = io.mimeType || ioMock.getMimeType(name);
-                                                                                                                        if (verbose) log.info(prettify(mimeType, "Mocked io.getMimeType(" + JSON.stringify(name) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked io.getMimeType(" + JSON.stringify(name) + "): " + JSON.stringify(mimeType, null, 2));
             return mimeType;
         }
     );
@@ -187,7 +113,7 @@ const doMocks = (params={}, verbose= false) => {
     mockedEtagreaderFuncs.read = etagReader.read || (
         (path, etagOverride) => {
             const etag = etagReader.etag || "MockedETagPlaceholder";
-                                                                                                                        if (verbose) log.info(prettify(etag, "Mocked etagReader.read(" + JSON.stringify({path, etagOverride}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked etagReader.read(" + JSON.stringify({path, etagOverride}) + "): " + JSON.stringify(etag, null, 2));
             return etag;
         }
     );
@@ -202,14 +128,14 @@ const doMocks = (params={}, verbose= false) => {
             : ioMock.getMimeType,
         cacheControlFunc: (optionParams.cacheControl !== undefined)
             ? () => optionParams.cacheControl
-            : () => DEFAULT_CACHE_CONTROL
+            : () => constants.DEFAULT_CACHE_CONTROL
     };
     mockedOptionsparserFuncs.parsePathAndOptions = optionParams.parsePathAndOptions || (
         (pathOrOptions, options) => {
             const parsed = (typeof pathOrOptions === 'string')
                 ? { path: pathOrOptions, ...defaultOptions, ...options, ...optionParams }
                 : { ...defaultOptions, ...pathOrOptions, ...optionParams };
-                                                                                                                        if (verbose) log.info(prettify(parsed, "Mocked parseRootAndOptions(" + JSON.stringify({pathOrOptions, options}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked parseRootAndOptions(" + JSON.stringify({pathOrOptions, options}) + "): " + JSON.stringify(parsed, null, 2));
             return parsed;
         }
     );
@@ -218,7 +144,7 @@ const doMocks = (params={}, verbose= false) => {
             const parsed = (typeof rootOrOptions === 'string')
                 ? { root: rootOrOptions, ...defaultOptions, ...options, ...optionParams }
                 : { ...defaultOptions, ...rootOrOptions, ...optionParams };
-                                                                                                                        if (verbose) log.info(prettify(parsed, "Mocked parseRootAndOptions(" + JSON.stringify({rootOrOptions, options}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked parseRootAndOptions(" + JSON.stringify({rootOrOptions, options}) + "): " + JSON.stringify(parsed, null, 2));
             return parsed;
         }
     );

--- a/src/test/resources/lib/enonic/static/static-test.es6
+++ b/src/test/resources/lib/enonic/static/static-test.es6
@@ -1,5 +1,4 @@
-const DEFAULT_CACHE_CONTROL = require('/lib/enonic/static/options').DEFAULT_CACHE_CONTROL;
-
+const constants = require('/lib/enonic/static/constants');
 const ioMock = require('/lib/enonic/static/ioMock');
 
 const t = require('/lib/xp/testing');
@@ -32,78 +31,6 @@ const lib = require('./index');
 
 //////////////////////////////////////////////////////////////////  HELPERS
 
-                                                                                                                        const prettify = (obj, label, suppressCode= false, indent = 0) => {
-                                                                                                                            let str = " ".repeat(indent) + (
-                                                                                                                                label !== undefined
-                                                                                                                                    ? label + ": "
-                                                                                                                                    : ""
-                                                                                                                            );
-
-                                                                                                                            if (typeof obj === 'function') {
-                                                                                                                                if (!suppressCode) {
-                                                                                                                                    return `${str}···· (function)\n${" ".repeat(indent + 4)}` +
-                                                                                                                                        obj.toString()
-                                                                                                                                            .replace(
-                                                                                                                                                /\r?\n\r?/g,
-                                                                                                                                                `\n${" ".repeat(indent + 4)}`
-                                                                                                                                            ) +
-                                                                                                                                        "\n" + " ".repeat(indent) + "····"
-                                                                                                                                        ;
-                                                                                                                                } else {
-                                                                                                                                    return `${str}···· (function)`;
-                                                                                                                                }
-
-                                                                                                                            } else if (Array.isArray(obj)) {
-                                                                                                                                return obj.length === 0
-                                                                                                                                    ? `${str}[]`
-                                                                                                                                    : (
-                                                                                                                                        `${str}[\n` +
-                                                                                                                                        obj.map(
-                                                                                                                                            (item, i) =>
-                                                                                                                                                prettify(item, i, suppressCode, indent + 4)
-                                                                                                                                        )
-                                                                                                                                            .join(",\n") +
-                                                                                                                                        `\n${" ".repeat(indent)}]`
-                                                                                                                                    );
-
-                                                                                                                            } else if (obj && typeof obj === 'object') {
-                                                                                                                                try {
-                                                                                                                                    if (Object.keys(obj).length === 0) {
-                                                                                                                                        return `${str}{}`;
-                                                                                                                                    } else {
-                                                                                                                                        return `${str}{\n` +
-                                                                                                                                            Object.keys(obj).map(
-                                                                                                                                                key => prettify(obj[key], key, suppressCode, indent + 4)
-                                                                                                                                            ).join(",\n") +
-                                                                                                                                            `\n${" ".repeat(indent)}}`
-                                                                                                                                    }
-                                                                                                                                } catch (e) {
-                                                                                                                                    log.info(e);
-                                                                                                                                    return `${str}···· (${typeof obj})\n${" ".repeat(indent + 4)}` +
-                                                                                                                                        obj.toString()
-                                                                                                                                            .replace(
-                                                                                                                                                /\r?\n\r?/g,
-                                                                                                                                                `\n${" ".repeat(indent + 4)}`
-                                                                                                                                            ) +
-                                                                                                                                        "\n" + " ".repeat(indent) + `····`;
-                                                                                                                                }
-                                                                                                                            } else if (obj === undefined || obj === null) {
-                                                                                                                                return `${str}${obj}`;
-                                                                                                                            } else if (JSON.stringify(obj) !== undefined) {
-                                                                                                                                return `${str}` + JSON.stringify(obj, null, 2).replace(
-                                                                                                                                    /\r?\n\r?/g,
-                                                                                                                                    `\n${" ".repeat(indent + 2)}`
-                                                                                                                                );
-                                                                                                                            } else {
-                                                                                                                                return `${str}···· (${typeof obj})\n${" ".repeat(indent + 4)}` +
-                                                                                                                                    obj.toString()
-                                                                                                                                        .replace(
-                                                                                                                                            /\r?\n\r?/g,
-                                                                                                                                            `\n${" ".repeat(indent + 4)}`
-                                                                                                                                        ) +
-                                                                                                                                    "\n" + " ".repeat(indent) + `····`;
-                                                                                                                            }
-                                                                                                                        };
 
 /* Mocks runMode.js, io.js, etagReader.js and options.js.
   Optional params: {
@@ -146,7 +73,7 @@ const doMocks = (params={}, verbose= false) => {
 
     mockedRunmodeFuncs.isDev = (typeof params.isDev === 'boolean' )
         ? () => {
-                                                                                                                        if (verbose) log.info(prettify(params.isDev, "Mocked isDev"));
+                                                                                                                        if (verbose) log.info("Mocked isDev: " + JSON.stringify(params.isDev, null, 2));
             return params.isDev
         }
         : () => false;
@@ -165,21 +92,21 @@ const doMocks = (params={}, verbose= false) => {
 
             const res = ioMock.getResource(data.path, data.exists, data.content);
 
-                                                                                                                        if (verbose) log.info(prettify(data, "Mocked io.getResource(" + JSON.stringify(path) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked io.getResource(" + JSON.stringify(path) + "): " + JSON.stringify(data, null, 2));
             return res;
         }
     );
     mockedIoFuncs.readText = io.readText || (
         (stream) => {
             const text = io.text || ioMock.readText(stream);
-                                                                                                                        if (verbose) log.info(prettify(text,"Mocked io.readText(stream)"));
+                                                                                                                        if (verbose) log.info("Mocked io.readText(stream): " + JSON.stringify(text, null, 2));
             return text;
         }
     );
     mockedIoFuncs.getMimeType = io.getMimeType || (
         (name) => {
             const mimeType = io.mimeType || ioMock.getMimeType(name);
-                                                                                                                        if (verbose) log.info(prettify(mimeType, "Mocked io.getMimeType(" + JSON.stringify(name) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked io.getMimeType(" + JSON.stringify(name) + "): " + JSON.stringify(mimeType, null, 2));
             return mimeType;
         }
     );
@@ -191,7 +118,7 @@ const doMocks = (params={}, verbose= false) => {
     mockedEtagreaderFuncs.read = etagReader.read || (
         (path, etagOverride) => {
             const etag = etagReader.etag || "MockedETagPlaceholder";
-                                                                                                                        if (verbose) log.info(prettify(etag, "Mocked etagReader.read(" + JSON.stringify({path, etagOverride}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked etagReader.read(" + JSON.stringify({path, etagOverride}) + "): " + JSON.stringify(etag, null, 2));
             return etag;
         }
     );
@@ -206,14 +133,14 @@ const doMocks = (params={}, verbose= false) => {
             : ioMock.getMimeType,
         cacheControlFunc: (optionParams.cacheControl !== undefined)
             ? () => optionParams.cacheControl
-            : () => DEFAULT_CACHE_CONTROL
+            : () => constants.DEFAULT_CACHE_CONTROL
     };
     mockedOptionsparserFuncs.parsePathAndOptions = optionParams.parsePathAndOptions || (
         (pathOrOptions, options) => {
             const parsed = (typeof pathOrOptions === 'string')
                 ? { path: pathOrOptions, ...defaultOptions, ...options, ...optionParams }
                 : { ...defaultOptions, ...pathOrOptions, ...optionParams };
-                                                                                                                        if (verbose) log.info(prettify(parsed, "Mocked parseRootAndOptions(" + JSON.stringify({pathOrOptions, options}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked parseRootAndOptions(" + JSON.stringify({pathOrOptions, options}) + "): " + JSON.stringify(parsed, null, 2));
             return parsed;
         }
     );
@@ -222,7 +149,7 @@ const doMocks = (params={}, verbose= false) => {
             const parsed = (typeof rootOrOptions === 'string')
                 ? { root: rootOrOptions, ...defaultOptions, ...options, ...optionParams }
                 : { ...defaultOptions, ...rootOrOptions, ...optionParams };
-                                                                                                                        if (verbose) log.info(prettify(parsed, "Mocked parseRootAndOptions(" + JSON.stringify({rootOrOptions, options}) + ")"));
+                                                                                                                        if (verbose) log.info("Mocked parseRootAndOptions(" + JSON.stringify({rootOrOptions, options}) + "): " + JSON.stringify(parsed, null, 2));
             return parsed;
         }
     );
@@ -256,8 +183,8 @@ exports.testbuildGetter_innerbehavior_1arg_parseRootAndOptions_isCalled = () => 
     doMocks({
             options: {
                 parseRootAndOptions: (rootOrOptions, options) => {
-                                                                                                                        if (verbose) log.info(prettify(rootOrOptions, "parseRootAndOptions call - rootOrOptions"));
-                                                                                                                        if (verbose) log.info(prettify(options, "parseRootAndOptions call - options"));
+                                                                                                                        if (verbose) log.info("parseRootAndOptions call - rootOrOptions: " + JSON.stringify(rootOrOptions, null, 2));
+                                                                                                                        if (verbose) log.info("parseRootAndOptions call - options: " + JSON.stringify(options, null, 2));
 
                     // Verify that the arguments of .buildGetter are passed into parseRootAndOptions the expected way:
                     t.assertEquals(undefined, options, "parseRootAndOptions: options");
@@ -292,7 +219,7 @@ exports.testbuildGetter_innerbehavior_1arg_parseRootAndOptions_isCalled = () => 
         etag: 'etag/should/be/boolean/but/ok',
         getCleanPath: 'getCleanPath/should/be/function/but/ok'
     });
-                                                                                                                        if (verbose) log.info(prettify(getStatic, "getStatic"));
+                                                                                                                        if (verbose) log.info("getStatic: " + JSON.stringify(getStatic, null, 2));
     t.assertTrue(parseRootAndOptionsWasCalled, "parseRootAndOptionsWasCalled");
 };
 
@@ -303,8 +230,8 @@ exports.testbuildGetter_innerbehavior_2arg_parseRootAndOptions_isCalled = () => 
     doMocks({
             options: {
                 parseRootAndOptions: (rootOrOptions, options) => {
-                                                                                                                        if (verbose) log.info(prettify(rootOrOptions, "parseRootAndOptions call - rootOrOptions"));
-                                                                                                                        if (verbose) log.info(prettify(options, "parseRootAndOptions call - options"));
+                                                                                                                        if (verbose) log.info("parseRootAndOptions call - rootOrOptions: " + JSON.stringify(rootOrOptions, null, 2));
+                                                                                                                        if (verbose) log.info("parseRootAndOptions call - options: " + JSON.stringify(options, null, 2));
 
                     // Verify that the arguments of .buildGetter are passed into parseRootAndOptions the expected way:
                     t.assertEquals('my/root', rootOrOptions , "parseRootAndOptions: rootOrOptions");
@@ -341,7 +268,7 @@ exports.testbuildGetter_innerbehavior_2arg_parseRootAndOptions_isCalled = () => 
             getCleanPath: 'getCleanPath/should/be/function/but/ok'
         }
     );
-                                                                                                                        if (verbose) log.info(prettify(getStatic, "getStatic"));
+                                                                                                                        if (verbose) log.info("getStatic: " + JSON.stringify(getStatic, null, 2));
     t.assertTrue(parseRootAndOptionsWasCalled, "parseRootAndOptionsWasCalled");
 };
 
@@ -360,7 +287,7 @@ exports.testbuildGetter_innerbehavior_parseRootAndOptions_errorMessage_shouldThr
     try {
         const getStatic = lib.buildGetter("my/root");
         failed = false;
-                                                                                                                        if (verbose) log.info(prettify(getStatic, "getStatic"));
+                                                                                                                        if (verbose) log.info("getStatic: " + JSON.stringify(getStatic, null, 2));
     } catch (e) {
                                                                                                                         if (verbose) log.error(e);
         t.assertTrue(e.message.indexOf("on purpose") > -1, "Expected purposefully thrown error");
@@ -436,7 +363,7 @@ exports.testbuildGetter_innerbehavior_parseRootAndOptions_outputs_areUsed = () =
         cacheControl: 'arg/cacheControl/in',
         contentType: 'arg/contentType/in'
     });
-                                                                                                                        if (verbose) log.info(prettify(getStatic, "getStatic"));
+                                                                                                                        if (verbose) log.info("getStatic: " + JSON.stringify(getStatic, null, 2));
     t.assertTrue(parseRootAndOptionsWasCalled, "parseRootAndOptionsWasCalled");
 
     t.assertFalse(getResourceWasCalled, "getResourceWasCalled");
@@ -472,7 +399,7 @@ exports.testbuildGetter_root_noLeadingSlash_isOK = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/i/am/root/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -489,7 +416,7 @@ exports.testbuildGetter_root_trailingSlash_isOK = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/i/am/root/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -505,7 +432,7 @@ exports.testGetStatic_rawPath_noLeadingSlash_isOK = () => {
         rawPath: 'assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/i/am/root/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -522,7 +449,7 @@ exports.testGetStatic_contextPath_trailingSlash_isOK = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: 'assets/'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/i/am/root/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -538,7 +465,7 @@ exports.testGetStatic_contextPath_noLeadingSlash_isOK = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: 'assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/i/am/root/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -554,7 +481,7 @@ exports.testGetStatic_request_noLeadingSlashes_isOK = () => {
         rawPath: 'assets/asset-test-target.txt',
         contextPath: 'assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/i/am/root/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -570,7 +497,7 @@ exports.testGetStatic_request_otherSlashes_isOK = () => {
         rawPath: 'assets/asset-test-target.txt',
         contextPath: 'assets/'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/i/am/root/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -594,7 +521,7 @@ exports.testGetStatic_root_string_FullDefaultResponse = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/i/am/root/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
 
@@ -605,7 +532,7 @@ exports.testGetStatic_root_string_FullDefaultResponse = () => {
     t.assertEquals('object', typeof result.headers, "result.headers should be an object with ETag and Cache-Control");
     t.assertEquals( "MockedETagPlaceholder", result.headers.ETag, "result.headers should be an object with ETag and Cache-Control");
     t.assertTrue(result.headers.ETag.length > 0, "result.headers should be an object with ETag and Cache-Control");
-    t.assertEquals(DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
 };
 
 exports.testGetStatic_root_option_FullDefaultResponse = () => {
@@ -617,7 +544,7 @@ exports.testGetStatic_root_option_FullDefaultResponse = () => {
     const result = getStatic({
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
-    });                                                                                                                 if (verbose) log.info(prettify(result, "result"));
+    });                                                                                                                 if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/i/am/root/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -629,7 +556,7 @@ exports.testGetStatic_root_option_FullDefaultResponse = () => {
     t.assertEquals('object', typeof result.headers, "result.headers should be an object with ETag and Cache-Control");
     t.assertEquals( "MockedETagPlaceholder", result.headers.ETag, "result.headers should be an object with ETag and Cache-Control");
     t.assertTrue(result.headers.ETag.length > 0, "result.headers should be an object with ETag and Cache-Control");
-    t.assertEquals(DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
 
 };
 
@@ -643,7 +570,7 @@ exports.testGetStatic_DEV_root_string_FullDefaultResponse = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/i/am/root/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -655,7 +582,7 @@ exports.testGetStatic_DEV_root_string_FullDefaultResponse = () => {
     t.assertEquals('object', typeof result.headers, "result.headers should be an object with ETag and Cache-Control");
     t.assertEquals( "MockedETagPlaceholder", result.headers.ETag, "result.headers should be an object with ETag and Cache-Control");
     t.assertTrue(result.headers.ETag.length > 0, "result.headers should be an object with ETag and Cache-Control");
-    t.assertEquals(DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
 };
 
 exports.testGetStatic_DEV_root_option_FullDefaultResponse = () => {
@@ -668,7 +595,7 @@ exports.testGetStatic_DEV_root_option_FullDefaultResponse = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
     t.assertEquals("Mocked content of '/i/am/root/asset-test-target.txt'", ioMock.readText(result.body), "result.body");
@@ -680,7 +607,7 @@ exports.testGetStatic_DEV_root_option_FullDefaultResponse = () => {
     t.assertEquals('object', typeof result.headers, "result.headers should be an object with ETag and Cache-Control");
     t.assertEquals( "MockedETagPlaceholder", result.headers.ETag, "result.headers should be an object with ETag and Cache-Control");
     t.assertTrue(result.headers.ETag.length > 0, "result.headers should be an object with ETag and Cache-Control");
-    t.assertEquals(DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
+    t.assertEquals(constants.DEFAULT_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and Cache-Control");
 };
 
 
@@ -691,8 +618,8 @@ exports.testGetStatic_contentType = () => {
     doMocks({
             options: {
                 contentTypeFunc: (filePathAndName, resource) => {
-                                                                                                                        if (verbose) log.info(prettify(filePathAndName, "contentTypeFunc.filePathAndName"));
-                                                                                                                        if (verbose) log.info(prettify(resource, "contentTypeFunc.resource"));
+                                                                                                                        if (verbose) log.info("contentTypeFunc.filePathAndName: " + JSON.stringify(filePathAndName, null, 2));
+                                                                                                                        if (verbose) log.info("contentTypeFunc.resource: " + JSON.stringify(resource, null, 2));
                     if (filePathAndName.endsWith(".html")) {
                         return "teKSt/html";
                     }
@@ -715,7 +642,7 @@ exports.testGetStatic_contentType = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result1, "result1"));
+                                                                                                                        if (verbose) log.info("result1: " + JSON.stringify(result1, null, 2));
 
     t.assertEquals(200, result1.status, "result1.status");
 
@@ -728,7 +655,7 @@ exports.testGetStatic_contentType = () => {
         rawPath: '/assets/asset-test-target.html',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result2, "result2"));
+                                                                                                                        if (verbose) log.info("result2: " + JSON.stringify(result2, null, 2));
 
     t.assertEquals(200, result2.status, "result2.status");
 
@@ -741,7 +668,7 @@ exports.testGetStatic_contentType = () => {
         rawPath: '/assets/asset-test-target.json',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result3, "result3"));
+                                                                                                                        if (verbose) log.info("result3: " + JSON.stringify(result3, null, 2));
 
     t.assertEquals(200, result3.status, "result3.status");
 
@@ -757,9 +684,9 @@ exports.testGetStatic_cacheControl = () => {
     doMocks({
             options: {
                 cacheControlFunc: (filePathAndName, resource, mimeType) => {
-                                                                                                                        if (verbose) log.info(prettify(filePathAndName, "cacheControlFunc.filePathAndName"));
-                                                                                                                        if (verbose) log.info(prettify(resource, "cacheControlFunc.resource"));
-                                                                                                                        if (verbose) log.info(prettify(mimeType, "cacheControlFunc.mimeType"));
+                                                                                                                        if (verbose) log.info("cacheControlFunc.filePathAndName: " + JSON.stringify(filePathAndName, null, 2));
+                                                                                                                        if (verbose) log.info("cacheControlFunc.resource: " + JSON.stringify(resource, null, 2));
+                                                                                                                        if (verbose) log.info("cacheControlFunc.mimeType: " + JSON.stringify(mimeType, null, 2));
                     if (filePathAndName.endsWith(".html")) {
                         return "htmlthmlhtml";
                     }
@@ -780,7 +707,7 @@ exports.testGetStatic_cacheControl = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result1, "result1"));
+                                                                                                                        if (verbose) log.info("result1: " + JSON.stringify(result1, null, 2));
 
     t.assertEquals(200, result1.status, "result1.status");
 
@@ -793,7 +720,7 @@ exports.testGetStatic_cacheControl = () => {
         rawPath: '/assets/asset-test-target.html',
         contextPath: '/assets'
     });
-    if (verbose) log.info(prettify(result2, "result2"));
+    if (verbose) log.info("result2: " + JSON.stringify(result2, null, 2));
 
     t.assertEquals(200, result2.status, "result2.status");
 
@@ -807,7 +734,7 @@ exports.testGetStatic_cacheControl = () => {
         rawPath: '/assets/asset-test-target.json',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result3, "result3"));
+                                                                                                                        if (verbose) log.info("result3: " + JSON.stringify(result3, null, 2));
 
     t.assertEquals(200, result3.status, "result3.status");
 
@@ -833,8 +760,8 @@ exports.testGetStatic_getCleanPath = () => {
     const result1 = getStatic({
         targetPath: '/myprefix/subfolder/asset-target1.txt',
     });
-                                                                                                                        if (verbose) log.info(prettify(result1, "result1"));
-                                                                                                                        if (verbose) log.info(prettify(ioMock.readText(result1.body), "result1.body content"));
+                                                                                                                        if (verbose) log.info("result1: " + JSON.stringify(result1, null, 2));
+                                                                                                                        if (verbose) log.info("result1.body content: " + JSON.stringify(ioMock.readText(result1.body), null, 2));
 
     t.assertEquals(200, result1.status, "result1.status");
     t.assertTrue(ioMock.readText(result1.body).indexOf("/i/am/root/subfolder/asset-target1.txt") !== -1, "Expected result1 body containing content of '/i/am/root/subfolder/asset-target1.txt'");
@@ -844,8 +771,8 @@ exports.testGetStatic_getCleanPath = () => {
     const result2 = getStatic({
         targetPath: '/myprefix/asset-target2.txt',
     });
-                                                                                                                        if (verbose) log.info(prettify(result2, "result2"));
-                                                                                                                        if (verbose) log.info(prettify(ioMock.readText(result2.body), "result2.body content"));
+                                                                                                                        if (verbose) log.info("result2: " + JSON.stringify(result2, null, 2));
+                                                                                                                        if (verbose) log.info("result2.body content: " + JSON.stringify(ioMock.readText(result2.body), null, 2));
 
     t.assertEquals(200, result2.status, "result2.status");
     t.assertTrue(ioMock.readText(result2.body).indexOf("/i/am/root/asset-target2.txt") !== -1, "Expected result2 body containing content of '/i/am/root/asset-target2.txt'");
@@ -872,7 +799,7 @@ exports.testGetStatic_root_noExist_shouldOnly404 = () => {
         contextPath: '/assets'
     });
 
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(404, result.status, "result.status");
 
@@ -897,7 +824,7 @@ exports.testGetStatic_DEV_root_noExist_should404withInfo = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(404, result.status, "result.status");
     t.assertEquals('string', typeof result.body, "Expected string body containing path in dev");
@@ -910,47 +837,208 @@ exports.testGetStatic_DEV_root_noExist_should404withInfo = () => {
 };
 
 
-exports.testGetStatic_relativePath_empty_shouldOnly400 = () => {
-                                                                                                                        if (verbose) log.info("\n\n\ntestGetStatic_relativePath_empty_shouldOnly400:\n");
-    doMocks({}, verbose);
+exports.testGetStatic_relativePath_slash_indexfallbackExists_shouldFallbackWith200andMustRevalidate = () => {
+    //const verbose = true;
+                                                                                                                        if (verbose) log.info("\n\n\ntestGetStatic_relativePath_slash_indexfallbackExists_shouldFallbackWith200andMustRevalidate:\n");
+    doMocks({
+        io: {
+            getResource: (path) => {
+                const data = {
+                    path: path,
+                    exists: path.endsWith("/index.html") // Mocking: '/i/am/root' will not exist, but '/i/am/root/index.html' will, during the fallback detection
+                };
+                data.content = `Mocked content of '${path}'`;
+
+                const res = ioMock.getResource(data.path, data.exists, data.content);
+
+                if (verbose) log.info("Mocked io.getResource(" + JSON.stringify(path) + "): " + JSON.stringify(data, null, 2));
+                return res;
+            }
+        }
+    }, verbose);
 
     const getStatic = lib.buildGetter({root: '/i/am/root'});
 
     const result = getStatic({
-        rawPath: '/assets/',
+        rawPath: '/assets/',        // Trailing slash, compared to contextPath it resolves relativePath to '/'
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
-    t.assertEquals(400, result.status, "result.status");
+    t.assertEquals(200, result.status, "result.status");
+    t.assertEquals("Mocked content of '/i/am/root/index.html'", ioMock.readText(result.body), "result.body");
+
+    t.assertEquals('string', typeof result.contentType, "Expected string contentType containing 'text/html'");
+    t.assertTrue(result.contentType.indexOf("text/html") !== -1, "Expected string contentType containing 'text/html'");
+
+    t.assertTrue(!!result.headers, "result.headers should be an object with ETag and Cache-Control");
+    t.assertEquals('object', typeof result.headers, "result.headers should be an object with ETag and Cache-Control");
+    t.assertEquals( "MockedETagPlaceholder", result.headers.ETag, "result.headers should be an object with ETag and 'no-cache' Cache-Control");
+    t.assertTrue(result.headers.ETag.length > 0, "result.headers should be an object with ETag and 'no-cache' Cache-Control");
+    t.assertEquals(constants.INDEXFALLBACK_CACHE_CONTROL, result.headers["Cache-Control"], "result.headers should be an object with ETag and 'no-cache' Cache-Control");
+
+    t.assertEquals(undefined, result.redirect, "result.redirect");
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
+}
+
+exports.testGetStatic_relativePath_slash_fallbackNotExist_shouldOnly404 = () => {
+    //const verbose = true;
+                                                                                                                        if (verbose) log.info("\n\n\ntestGetStatic_relativePath_slash_fallbackNotExist_shouldOnly404:\n");
+    doMocks({
+        io: {
+            exists: false
+        }
+    }, verbose);
+
+    const getStatic = lib.buildGetter({root: '/i/am/root'});
+
+    const result = getStatic({
+        rawPath: '/assets/',        // Trailing slash, compared to contextPath it resolves relativePath to '/'
+        contextPath: '/assets'
+    });
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
+
+    t.assertEquals(404, result.status, "result.status");
 
     t.assertEquals(undefined, result.body, "result.body");
     t.assertEquals(undefined, result.contentType, "result.contentType");
     t.assertEquals(undefined, result.headers, "result.headers");
+    t.assertEquals(undefined, result.redirect, "result.redirect");
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 }
 
-
-exports.testGetStatic_DEV_relativePath_empty_should400WithInfo = () => {
-                                                                                                                        if (verbose) log.info("\n\n\ntestGetStatic_DEV_relativePath_empty_should400WithInfo:\n");
-    doMocks({ isDev: true }, verbose);
+exports.testGetStatic_DEV_relativePath_slash_fallbackNotExist_should404withInfo = () => {
+    //const verbose = true;
+                                                                                                                        if (verbose) log.info("\n\n\ntestGetStatic_DEV_relativePath_slash_fallbackNotExist_should404withInfo:\n");
+    doMocks({
+        isDev: true,
+        io: {
+            exists: false
+        }
+    }, verbose);
 
     const getStatic = lib.buildGetter({root: '/i/am/root'});
 
     const result = getStatic({
-        rawPath: '/assets/',
+        rawPath: '/assets/',        // Trailing slash, compared to contextPath it resolves relativePath to '/'
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
-    t.assertEquals(400, result.status, "result.status");
+    t.assertEquals(404, result.status, "result.status");
 
-    t.assertEquals('string', typeof result.body, "Expected string body with error message in dev");
+    t.assertEquals('string', typeof result.body, "Expected string body containing path in dev");
+    t.assertTrue(result.body.indexOf('/i/am/root/') !== -1, "Expected string body containing path in dev");
 
     t.assertEquals('string', typeof result.contentType, "Expected string contentType containing 'text/plain' in dev");
     t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "Expected string contentType containing 'text/plain' in dev");
 
     t.assertEquals(undefined, result.headers, "result.headers");
+    t.assertEquals(undefined, result.redirect, "result.redirect");
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
 }
+
+
+exports.testGetStatic_relativePath_empty_fallbackExists_shouldRedirectToSlash = () => {
+    //const verbose = true;
+                                                                                                                        if (verbose) log.info("\n\n\ntestGetStatic_relativePath_empty_fallbackExists_shouldRedirectToSlash:\n");
+    doMocks({
+        io: {
+            getResource: (path) => {
+                const data = {
+                    path: path,
+                    exists: path.endsWith("/index.html") // Mocking: '/i/am/root' will not exist, but '/i/am/root/index.html' will, during the fallback detection
+                };
+                data.content = `Mocked content of '${path}'`;
+
+                const res = ioMock.getResource(data.path, data.exists, data.content);
+
+                                                                                                                        if (verbose) log.info("Mocked io.getResource(" + JSON.stringify(path) + "): " + JSON.stringify(data, null, 2));
+                return res;
+            }
+        }
+    }, verbose);
+
+    const getStatic = lib.buildGetter({root: '/i/am/root'});
+
+    const result = getStatic({
+        rawPath: '/assets',         // No trailing slash, compared with contextPath it will resolve relativePath to ''
+        contextPath: '/assets'
+    });
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
+
+    t.assertEquals('/assets/', result.redirect, "result.redirect");
+
+    t.assertEquals(undefined, result.status, "result.status");
+    t.assertEquals(undefined, result.body, "result.body");
+    t.assertEquals(undefined, result.contentType, "result.contentType");
+    t.assertEquals(undefined, result.headers, "result.headers");
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
+}
+
+exports.testGetStatic_relativePath_empty_fallbackNotExist_shouldOnly404 = () => {
+    //const verbose = true;
+                                                                                                                        if (verbose) log.info("\n\n\ntestGetStatic_relativePath_empty_fallbackNotExist_shouldOnly404:\n");
+    doMocks({
+        io: {
+            exists: false
+        }
+    }, verbose);
+
+    const getStatic = lib.buildGetter({root: '/i/am/root'});
+
+    const result = getStatic({
+        rawPath: '/assets',         // No trailing slash
+        contextPath: '/assets'
+    });
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
+
+    t.assertEquals(404, result.status, "result.status");
+
+    t.assertEquals(undefined, result.body, "result.body");
+    t.assertEquals(undefined, result.contentType, "result.contentType");
+    t.assertEquals(undefined, result.headers, "result.headers");
+    t.assertEquals(undefined, result.redirect, "result.redirect");
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
+}
+
+exports.testGetStatic_DEV_relativePath_empty_fallbackNotExist_should404withInfo = () => {
+    //const verbose = true;
+                                                                                                                        if (verbose) log.info("\n\n\ntestGetStatic_DEV_relativePath_empty_fallbackNotExist_should404withInfo:\n");
+    doMocks({
+        isDev: true,
+        io: {
+            exists: false
+        }
+    }, verbose);
+
+    const getStatic = lib.buildGetter({root: '/i/am/root'});
+
+    const result = getStatic({
+        rawPath: '/assets',         // No trailing slash
+        contextPath: '/assets'
+    });
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
+
+    t.assertEquals(404, result.status, "result.status");
+
+    t.assertEquals('string', typeof result.body, "Expected string body containing path in dev");
+    t.assertTrue(result.body.indexOf('/i/am/root') !== -1, "Expected string body containing path in dev");
+
+    t.assertEquals('string', typeof result.contentType, "Expected string contentType containing 'text/plain' in dev");
+    t.assertTrue(result.contentType.indexOf("text/plain") !== -1, "Expected string contentType containing 'text/plain' in dev");
+
+    t.assertEquals(undefined, result.headers, "result.headers");
+    t.assertEquals(undefined, result.redirect, "result.redirect");
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
+}
+
 
 
 
@@ -964,7 +1052,7 @@ exports.testGetStatic_relativePath_illegalChars_shouldOnly400 = () => {
         rawPath: '/assets/../asset-test-target/.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result1, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result1, null, 2));
 
     t.assertEquals(400, result1.status, "result1.status");
 
@@ -977,7 +1065,7 @@ exports.testGetStatic_relativePath_illegalChars_shouldOnly400 = () => {
         rawPath: '/assets/asset<test-target/.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result2, "result2"));
+                                                                                                                        if (verbose) log.info("result2: " + JSON.stringify(result2, null, 2));
 
     t.assertEquals(400, result2.status, "result2.status");
 
@@ -990,7 +1078,7 @@ exports.testGetStatic_relativePath_illegalChars_shouldOnly400 = () => {
         rawPath: '/assets/asset:test-target/.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result3, "result3"));
+                                                                                                                        if (verbose) log.info("result3: " + JSON.stringify(result3, null, 2));
 
     t.assertEquals(400, result3.status, "result3.status");
 
@@ -1010,7 +1098,7 @@ exports.testGetStatic_DEV_relativePath_illegalChars_should400WithInfo = () => {
         rawPath: '/assets/../asset-test-target/.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result1, "result1"));
+                                                                                                                        if (verbose) log.info("result1: " + JSON.stringify(result1, null, 2));
 
     t.assertEquals(400, result1.status, "result1.status");
 
@@ -1027,7 +1115,7 @@ exports.testGetStatic_DEV_relativePath_illegalChars_should400WithInfo = () => {
         rawPath: '/assets/asset\\test-target/.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result2, "result2"));
+                                                                                                                        if (verbose) log.info("result2: " + JSON.stringify(result2, null, 2));
 
     t.assertEquals(400, result2.status, "result2.status");
 
@@ -1044,7 +1132,7 @@ exports.testGetStatic_DEV_relativePath_illegalChars_should400WithInfo = () => {
         rawPath: '/assets/asset:test-target/.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result3, "result3"));
+                                                                                                                        if (verbose) log.info("result3: " + JSON.stringify(result3, null, 2));
 
     t.assertEquals(400, result3.status, "result3.status");
 
@@ -1066,7 +1154,7 @@ exports.testGetStatic_noRawPath_should500 = () => {
     const result = getStatic({
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(500, result.status, "result.status");
 
@@ -1088,7 +1176,7 @@ exports.testGetStatic_noContextPath_should500 = () => {
     const result = getStatic({
         rawPath: '/assets/asset-test-target.txt',
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(500, result.status, "result.status");
 
@@ -1111,7 +1199,7 @@ exports.testGetStatic_outsideContextPath_should500 = () => {
         rawPath: 'assets/asset-test-target.txt',
         contextPath: 'my/endpoint'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(500, result.status, "result.status");
 
@@ -1145,7 +1233,7 @@ exports.testGetStatic_throwErrors_shouldThrowErrorInsteadOf500 = () => {
             rawPath: '/assets/asset-test-target.txt',
         });
         failed = false;
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
     } catch (e) {
                                                                                                                         if (verbose) log.error(e);
     }
@@ -1172,7 +1260,7 @@ exports.testGetStatic_failingContentTypeFunc_should500 = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(500, result.status, "result.status");
 }
@@ -1199,7 +1287,7 @@ exports.testGetStatic_failingContentTypeFunc_throwErrors_shouldThrowErrorInstead
             contextPath: '/assets'
         });
         failed = false;
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
     } catch (e) {
                                                                                                                         if (verbose) log.error(e);
         t.assertTrue(e.message.indexOf("on purpose") > -1, "Thrown error should have been on purpose");
@@ -1229,7 +1317,7 @@ exports.testGetStatic_failingCacheControlFunc_should500 = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(500, result.status, "result.status");
 }
@@ -1256,7 +1344,7 @@ exports.testGetStatic_failingCacheControlFunc_throwErrors_shouldThrowErrorInstea
             contextPath: '/assets'
         });
         failed = false;
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
     } catch (e) {
                                                                                                                         if (verbose) log.error(e);
         t.assertTrue(e.message.indexOf("on purpose") > -1, "Thrown error should have been on purpose");
@@ -1286,7 +1374,7 @@ exports.testGetStatic_failingGetCleanPath_should500 = () => {
         rawPath: '/assets/asset-test-target.txt',
         contextPath: '/assets'
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(500, result.status, "result.status");
 }
@@ -1313,7 +1401,7 @@ exports.testGetStatic_failingGetCleanPath_throwErrors_shouldThrowErrorInsteadOf5
             contextPath: '/assets'
         });
         failed = false;
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
     } catch (e) {
                                                                                                                         if (verbose) log.error(e);
         t.assertTrue(e.message.indexOf("on purpose") > -1, "Thrown error should have been on purpose");
@@ -1349,7 +1437,7 @@ exports.testGetStatic_ifMatchingEtag_should304 = () => {
             'If-None-Match': 'test-etag-value'
         }
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(304, result.status, "result.status");
 
@@ -1380,7 +1468,7 @@ exports.testGetStatic_ifNotMatchingEtag_shouldProceedWithAssetRead = () => {
             'If-None-Match': 'OLD-etag-value'
         }
     });
-                                                                                                                        if (verbose) log.info(prettify(result, "result"));
+                                                                                                                        if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
 
     t.assertEquals(200, result.status, "result.status");
 
@@ -1392,12 +1480,12 @@ exports.testGetStatic_ifNotMatchingEtag_shouldProceedWithAssetRead = () => {
 
 // Verify that a even if the getStatic function fails once, it will keep working for new requests later
 exports.testGetStatic_fail_failuresShouldNotDestroyGetstaticFunction = () => {
-    // const verbose = true;
+    //const verbose = true;
                                                                                                                         if (verbose) log.info("\n\n\ntestGetStatic_fail_failuresShouldNotDestroyGetstaticFunction:\n");
 
     doMocks({}, verbose);
 
-    const getStatic = lib.buildGetter('static');
+    const getStatic = lib.buildGetter('i/am/root');
 
     let result;
 
@@ -1442,14 +1530,33 @@ exports.testGetStatic_fail_failuresShouldNotDestroyGetstaticFunction = () => {
     result = getStatic({rawPath: 'my/endpoint/w3c_home.gif', contextPath: 'my/endpoint'});
     t.assertEquals(200, result.status, "Expected 200 OK. Result: " + JSON.stringify(result));
 
+    doMocks({
+        io: {
+            getResource: (path) => {
+                const data = {
+                    path: path,
+                    exists: path.endsWith("/index.html") // Mocking: '/i/am/root' will not exist, but '/i/am/root/index.html' will, during the fallback detection
+                };
+                data.content = `Mocked content of '${path}'`;
+
+                const res = ioMock.getResource(data.path, data.exists, data.content);
+
+                                                                                                                        if (verbose) log.info("Mocked io.getResource(" + JSON.stringify(path) + "): " + JSON.stringify(data, null, 2));
+                return res;
+            }
+        }
+    }, verbose);
     result = getStatic({contextPath: 'my/endpoint'});
+    																													//if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
     t.assertTrue(result.status >= 400, "Expected a failing getStatic call: missing relative path. Result: " + JSON.stringify(result));
                                                                                                                         if (verbose) log.info(`OK: ${result.status} - ${result.body}`);
 
     result = getStatic({rawPath: 'my/endpoint/', contextPath: 'my/endpoint'});
-    t.assertTrue(result.status >= 400, "Expected a failing getStatic call: missing relative path. Result: " + JSON.stringify(result));
+                                                                                                                        // if (verbose) log.info("result: " + JSON.stringify(result, null, 2));
+    t.assertEquals(200, result.status, "Expected an index fallback, so, 200 OK. Result: " + JSON.stringify(result));
                                                                                                                         if (verbose) log.info(`OK: ${result.status} - ${result.body}`);
 
+    doMocks({}, verbose);
     result = getStatic({rawPath: 'my/endpoint/w3c_home.jpg', contextPath: 'my/endpoint'});
     t.assertEquals(200, result.status, "Expected 200 OK. Result: " + JSON.stringify(result));
 
@@ -1524,7 +1631,9 @@ exports.testGetStatic_fail_failuresShouldNotDestroyGetstaticFunction = () => {
 
     result = getStatic3({rawPath: 'my/endpoint/w3c_home.gif', contextPath: 'my/endpoint'});
     t.assertEquals(200, result.status, "no runtime error status");
-                                                                                                                        if (verbose) log.info(`OK: ${result.status} - ${result.body}`);
+
+                                                                                                                        if (verbose) t.assertTrue(false, "OK");
+    log.info(`OK: ${result.status} - ${result.body}`);
 }
 
 


### PR DESCRIPTION
- [x] If path does _not_ end with `/` and exists, just return it. Else:

- [x] If path does _not_ end with `/`:
    - [x] Append `/` and fallback-file to `path` and look for that
    - [x] If that exists, **append `/` to `request.rawPath` and redirect there.**
    - [x] If not, return 404
    
- [x] If path _does_ ends with `/`:
    - [x] Append fallback-file to `path` and look for it
    - [x] If that exists, **return it**
    - [x] If not, return 404

- [x] Fallback-file is `index.html`, but this might change later: #57. Prepared for this.

Needs a solution to #58, as well as docs (#59) and updated unit tests (#60: unit tests will fail before this). This PR is only functionality.