### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -15,6 +15,9 @@ jobs:
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
           codecovToken: ${{ secrets.CODECOV_TOKEN }}
           npmToken: ${{ secrets.NPM_TOKEN }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `releaseBranch: master / 2.x` to the `enonic/release-tools/build-and-publish` step on `2.x`, so the maintenance branch produces release artifacts (matches the app-booster maintenance-branch pattern).

This branch is the XP 7 maintenance line. `gradle.properties`, `enonic-docgen.yml`, and `docs/versions.json` are intentionally **not** touched here — those are master-only per the app-booster reference.

## Test plan

- [ ] Confirm `Gradle Build` workflow runs on `2.x` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)