### PR TITLE
Bump @enonic-types/* to ^8.0.0-B4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
       "name": "lib-static",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@enonic-types/core": "^7.16.3",
-        "@enonic-types/global": "7.16.3",
+        "@enonic-types/core": "^8.0.0-B4",
+        "@enonic-types/global": "^8.0.0-B4",
         "@enonic/eslint-config": "^2.3.0",
         "@eslint/js": "^10.0.1",
         "@item-enonic-types/lib-router": "^3.1.0",
@@ -737,20 +737,18 @@
       }
     },
     "node_modules/@enonic-types/core": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-7.16.3.tgz",
-      "integrity": "sha512-0TbkNHMO9xir/m92RavXL6XIM4L4zA5J4Tk1ettODrX+3YfcoFAXiGlPQanD0k4o3s79D0ZYPw2QKPhA2/OAdw==",
-      "dev": true,
-      "license": "Apache-2.0"
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-8.0.0-B4.tgz",
+      "integrity": "sha512-UGq6ixxLMOEQm5NYdjilWUIXugcGiEKAmzuzM1vBCltdJLJfqgJYjVgrziXhbiulpYdxcMoDTe0N8uF7R6j25w==",
+      "dev": true
     },
     "node_modules/@enonic-types/global": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@enonic-types/global/-/global-7.16.3.tgz",
-      "integrity": "sha512-dEMj48NHDSXVBK4c7eRZAGoh/3xM42Sbf0ZmsnQqxpB69SBfht5m6hXR/weHbnj1mhYPyjWCyB56R3Uhy7NLFg==",
+      "version": "8.0.0-B4",
+      "resolved": "https://registry.npmjs.org/@enonic-types/global/-/global-8.0.0-B4.tgz",
+      "integrity": "sha512-CC7OQvPOtxMBfOhnLcDYaMxfdSIaYkbDQ8WnDmXPEPDHMNkraZhirLpdvAnS/7PObS/yEuS94x9GEAqmEd+YFQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@enonic-types/core": "7.16.3"
+        "@enonic-types/core": "8.0.0-B4"
       }
     },
     "node_modules/@enonic/eslint-config": {
@@ -1554,6 +1552,12 @@
       "dependencies": {
         "@enonic-types/core": "^7.15.0"
       }
+    },
+    "node_modules/@item-enonic-types/lib-router/node_modules/@enonic-types/core": {
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@enonic-types/core/-/core-7.16.3.tgz",
+      "integrity": "sha512-0TbkNHMO9xir/m92RavXL6XIM4L4zA5J4Tk1ettODrX+3YfcoFAXiGlPQanD0k4o3s79D0ZYPw2QKPhA2/OAdw==",
+      "dev": true
     },
     "node_modules/@jest/console": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://developer.enonic.com/docs/lib-static",
   "devDependencies": {
-    "@enonic-types/core": "^7.16.3",
-    "@enonic-types/global": "7.16.3",
+    "@enonic-types/core": "^8.0.0-B4",
+    "@enonic-types/global": "^8.0.0-B4",
     "@enonic/eslint-config": "^2.3.0",
     "@eslint/js": "^10.0.1",
     "@item-enonic-types/lib-router": "^3.1.0",

--- a/src/bun/setup.ts
+++ b/src/bun/setup.ts
@@ -218,9 +218,9 @@ globalThis.__ = {
     }
     throw new Error(`Unmocked bean:${bean}!`);
   },
-  nullOrValue: <T>(v: T): T => {
+  nullOrValue: <T>(v: T) => {
     log.debug(`nullOrValue value:${JSON.stringify(v, null, 4)}`);
-    return v;
+    return v as T extends null | undefined ? null : T;
   },
   toNativeObject: <T>(v: T): T => {
     // log.debug(`toNativeObject value:${JSON.stringify(v, null, 4)}`);
@@ -232,8 +232,8 @@ globalThis.__ = {
     }
     throw new Error(`toNativeObject: Unmocked value:${JSON.stringify(v, null, 4)}!`);
   },
-  toScriptValue: <T>(v: T): ScriptValue => {
+  toScriptValue: <T>(v: T) => {
     log.debug(`toScriptValue value:${JSON.stringify(v, null, 4)}`);
-    return v as ScriptValue;
+    return v as T extends null | undefined ? null : ScriptValue;
   },
 };


### PR DESCRIPTION
## Summary
- Bumps `@enonic-types/core` from `^7.16.3` to `^8.0.0-B4`
- Bumps `@enonic-types/global` from `7.16.3` (no caret) to `^8.0.0-B4`
- Adapts the bun test mocks for `DoubleUnderscore.nullOrValue` / `DoubleUnderscore.toScriptValue` so they match the new conditional return types in `@enonic-types/core@8` (`T extends null | undefined ? null : ...`).

The library's own version is **not** changed (it stays at `3.0.0-SNAPSHOT`, set during the earlier XP 8 upgrade); only the consumer-side `@enonic-types/*` deps are bumped. The emitted `@enonic-types/lib-static` types package picks up the new `@enonic-types/core ^8.0.0-B4` dependency via `types/process.ts`.

Reference: enonic/doc-code@967803a (same bump pattern).

## Verification
- `npm run check` (tsc against all four tsconfigs + eslint) - green
- `npm run build` (tsup server bundle + types bundle) - green
- `npm test` (Jest, 3 suites / 9 tests) - green
- `./gradlew build -x test` - green

## Test plan
- [ ] CI passes on `feat/enonic-types-xp8`
- [ ] Verify a downstream consumer (e.g. an XP 8 app pulling `@enonic-types/lib-static`) compiles against the resulting snapshot types

🤖 Generated with [Claude Code](https://claude.com/claude-code)