### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,13 @@ dependencies {
   // Libraries included with implementation are available during both compile
   // time and runtime. This means your code can use the functionality of the
   // dependency while compiling and when the final application runs.
-  implementation 'com.enonic.lib:lib-router:4.0.0-SNAPSHOT'
+  implementation libs.lib.router
 
-  testImplementation( platform( "org.junit:junit-bom:6.0.3" ) )
-  testImplementation( platform( "org.mockito:mockito-bom:5.23.0" ) )
-  testImplementation 'org.junit.jupiter:junit-jupiter'
-  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-  testImplementation 'org.mockito:mockito-junit-jupiter'
+  testImplementation( platform( libs.junit.bom ) )
+  testImplementation( platform( libs.mockito.bom ) )
+  testImplementation libs.junit.jupiter
+  testRuntimeOnly libs.junit.platform.launcher
+  testImplementation libs.mockito.junit.jupiter
   testImplementation "com.enonic.xp:testing:${xpVersion}"
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,12 @@
+[versions]
+junit = "6.0.3"
+mockito = "5.23.0"
+router = "4.0.0-SNAPSHOT"
+
+[libraries]
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+lib-router = { module = "com.enonic.lib:lib-router", version.ref = "router" }
+mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }


### PR DESCRIPTION
## Summary

Move inline-versioned dependencies in `build.gradle` to a new `gradle/libs.versions.toml` catalog. Pin-for-pin migration — no version bumps, no behavioral changes. The resolved dependency tree (`runtimeClasspath`, `testRuntimeClasspath`, `compileClasspath`) is byte-identical before and after.

## Conventions adopted

- Version and library keys: short, lowercase, hyphen-separated.
- `[versions]` and `[libraries]` sorted alphabetically.
- `version.ref` for every entry that has a version (no inline `version = "x.y"` singletons in this repo).
- `xpVersion` left in `gradle.properties` — the rest of the toolchain expects it there.
- `xplibs.api.*` accessors untouched — those come from the XP gradle plugin, not the project's own catalog.

## Catalog

```toml
[versions]
junit = "6.0.3"
mockito = "5.23.0"
router = "4.0.0-SNAPSHOT"

[libraries]
junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
lib-router = { module = "com.enonic.lib:lib-router", version.ref = "router" }
mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
```

## Test plan

- [x] `./gradlew build --refresh-dependencies` — BUILD SUCCESSFUL
- [x] `./gradlew dependencies` diff (runtimeClasspath / testRuntimeClasspath / compileClasspath) — identical pre/post
- [x] JUnit + jest test suites pass; type checks (`tsc`) and eslint clean