### PR TITLE
Drop orphan lib-router dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,6 @@ dependencies {
   compileOnly xplibs.api.core
   compileOnly xplibs.api.script
 
-  // implementation: This is the most common way to specify a dependency.
-  // Libraries included with implementation are available during both compile
-  // time and runtime. This means your code can use the functionality of the
-  // dependency while compiling and when the final application runs.
-  implementation libs.lib.router
-
   testImplementation( platform( libs.junit.bom ) )
   testImplementation( platform( libs.mockito.bom ) )
   testImplementation libs.junit.jupiter

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,10 @@
 [versions]
 junit = "6.0.3"
 mockito = "5.23.0"
-router = "4.0.0-SNAPSHOT"
 
 [libraries]
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
-lib-router = { module = "com.enonic.lib:lib-router", version.ref = "router" }
 mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }


### PR DESCRIPTION
## Summary

`implementation libs.lib.router` is declared in `build.gradle` but never used. There is no `require('/lib/router')` / `import … from '/lib/router'` anywhere in `src/main` — `requestHandler.ts` and `spaNotFoundHandler.ts` are self-contained functions, and callers wire them up themselves.

The dep was likely a leftover from an earlier version where `requestHandler` was a router-based setup. Carrying it now:

- Adds `com.enonic.lib:lib-router:4.0.0-SNAPSHOT` to the resolved runtime classpath for no reason.
- Suggests to readers (and to consumers reading the resolved tree) that lib-static depends on lib-router internally, which it doesn't.

Removed from both `build.gradle` and `gradle/libs.versions.toml` (versions + libraries entries).

## What this does NOT change

- Public API (`requestHandler`, `spaNotFoundHandler`, `mappedRelativePath`) — unchanged.
- Consumer behavior — apps that pair `staticLib.requestHandler` with their own `lib-router` setup keep working; they declare lib-router themselves.

A follow-up on the docs side would help: lib-static's published guide should call out the common pattern of pairing it with `lib-router` for AdminExtension / IdProvider / UniversalAPI controllers (the contexts lib-asset can't serve). That's a separate change — this PR is the dependency cleanup only.

## Test plan

- [x] `./gradlew clean build --refresh-dependencies` — green inside `claude-dev`.
- [x] No source references to `/lib/router` in `src/main` (`grep -rEn '/lib/router' src/main` → empty).
- [ ] CI green.