### PR TITLE
Accept relativePath with or without leading slash #1012

### DIFF
--- a/src/jest/lib/enonic/static/resource/path/prefixWithRoot.test.ts
+++ b/src/jest/lib/enonic/static/resource/path/prefixWithRoot.test.ts
@@ -1,0 +1,34 @@
+import {
+  describe,
+  expect,
+  test as it
+} from '@jest/globals';
+import {prefixWithRoot} from '../../../../../../main/resources/lib/enonic/static/resource/path/prefixWithRoot';
+
+
+describe('prefixWithRoot', () => {
+  it('joins root and absolute path', () => {
+    expect(prefixWithRoot({root: '/static', path: '/styles.css'})).toEqual('/static/styles.css');
+  });
+
+  it('joins root and relative path (no leading slash)', () => {
+    expect(prefixWithRoot({root: '/static', path: 'styles.css'})).toEqual('/static/styles.css');
+  });
+
+  it('treats root without leading slash the same as with one', () => {
+    expect(prefixWithRoot({root: 'static', path: '/styles.css'})).toEqual('/static/styles.css');
+    expect(prefixWithRoot({root: 'static', path: 'styles.css'})).toEqual('/static/styles.css');
+  });
+
+  it('strips a single trailing slash from the result', () => {
+    expect(prefixWithRoot({root: '/static', path: '/styles.css/'})).toEqual('/static/styles.css');
+  });
+
+  it('throws when root is empty', () => {
+    expect(() => prefixWithRoot({root: '', path: '/styles.css'})).toThrow(/root must be a non-empty string/);
+  });
+
+  it('throws when root is only slashes', () => {
+    expect(() => prefixWithRoot({root: '///', path: '/styles.css'})).toThrow(/root must be a non-empty string/);
+  });
+});

--- a/src/main/resources/lib/enonic/static/resource/path/prefixWithRoot.ts
+++ b/src/main/resources/lib/enonic/static/resource/path/prefixWithRoot.ts
@@ -5,13 +5,14 @@ import {stringStartsWith} from '/lib/enonic/static/util/stringStartsWith';
  * Joins a static-resource `root` with a `path` to produce an absolute
  * resource path that always starts with `/` and has no trailing slash.
  *
- * `path` may be given in any of the following forms; all four resolve
- * identically:
+ * Canonical form for `path` has no leading slash: `'styles.css'`,
+ * `'css/main.css'`. A leading slash is accepted but redundant — both
+ * forms resolve identically:
  *
+ *   - `'styles.css'`   → `<root>/styles.css`   ← canonical
  *   - `'/styles.css'`  → `<root>/styles.css`
- *   - `'styles.css'`   → `<root>/styles.css`
- *   - `''`             → `<root>`         (root itself)
- *   - `'/'`            → `<root>`         (root itself)
+ *   - `''`             → `<root>`              (root itself)
+ *   - `'/'`            → `<root>`              (root itself)
  *
  * `root` is treated the same way: a missing leading `/` is added.
  *

--- a/src/main/resources/lib/enonic/static/resource/path/prefixWithRoot.ts
+++ b/src/main/resources/lib/enonic/static/resource/path/prefixWithRoot.ts
@@ -5,7 +5,7 @@ export function prefixWithRoot({
   root = GETTER_ROOT,
   path,
 }: {
-  path: string, // Can be empty string, or just a slash, or a full path starting with a slash
+  path: string, // Empty, a slash, or a path with or without a leading slash — all accepted.
   root?: string
 }): string {
   // NOTE: For security reasons it's very important that GETTER_ROOT is the root
@@ -16,6 +16,7 @@ export function prefixWithRoot({
     throw new Error(errorMessage);
   }
   const slashRoot = stringStartsWith(root, '/') ? root : `/${root}`;
-  return `${slashRoot}${path}`
+  const slashPath = stringStartsWith(path, '/') ? path : `/${path}`;
+  return `${slashRoot}${slashPath}`
     .replace(/\/$/, ''); // Remove trailing slash
 }

--- a/src/main/resources/lib/enonic/static/resource/path/prefixWithRoot.ts
+++ b/src/main/resources/lib/enonic/static/resource/path/prefixWithRoot.ts
@@ -1,11 +1,28 @@
 import {GETTER_ROOT} from '/lib/enonic/static/constants';
 import {stringStartsWith} from '/lib/enonic/static/util/stringStartsWith';
 
+/**
+ * Joins a static-resource `root` with a `path` to produce an absolute
+ * resource path that always starts with `/` and has no trailing slash.
+ *
+ * `path` may be given in any of the following forms; all four resolve
+ * identically:
+ *
+ *   - `'/styles.css'`  → `<root>/styles.css`
+ *   - `'styles.css'`   → `<root>/styles.css`
+ *   - `''`             → `<root>`         (root itself)
+ *   - `'/'`            → `<root>`         (root itself)
+ *
+ * `root` is treated the same way: a missing leading `/` is added.
+ *
+ * Throws if `root` is empty or consists only of slashes — for security
+ * (see GETTER_ROOT comment below).
+ */
 export function prefixWithRoot({
   root = GETTER_ROOT,
   path,
 }: {
-  path: string, // Empty, a slash, or a path with or without a leading slash — all accepted.
+  path: string,
   root?: string
 }): string {
   // NOTE: For security reasons it's very important that GETTER_ROOT is the root


### PR DESCRIPTION
Closes #1012.

## Summary

`prefixWithRoot` concatenates `${slashRoot}${path}` directly. When `path` doesn't start with `/`, the result is broken:

```
prefixWithRoot({root: '/static', path: 'styles.css'})  → '/staticstyles.css'
```

Existing internal callers (`getRelative`, `mappedRelativePath`) always produce a leading slash, so this never surfaced. It surfaces the moment a consumer hand-rolls `relativePath` from a router capture:

```ts
router.get('/_static/{path:.*}', (req) => requestHandler(req, {
  root: '/static/foo',
  relativePath: (r) => r.pathParams.path,       // 'styles.css'
}))
```

— that's the natural form when pairing lib-static with lib-router, but the path-without-leading-slash form silently produces wrong file lookups. See #1012 for the full motivation.

This PR normalises: `path` is prepended with `/` if it doesn't already have one. Canonical form has no leading slash; a leading slash is accepted as a redundant equivalent. Both forms now resolve identically:

```
prefixWithRoot({root: '/static', path: 'styles.css'})   → '/static/styles.css'   ← canonical
prefixWithRoot({root: '/static', path: '/styles.css'})  → '/static/styles.css'
prefixWithRoot({root: '/static', path: ''})             → '/static'
prefixWithRoot({root: '/static', path: '/'})            → '/static'
```

Existing callers are unaffected (their outputs already started with `/`).

## Documentation

A JSDoc block was added to `prefixWithRoot` listing the four equivalent forms, marking "no leading slash" as canonical, and naming the same flexibility for `root`.

## Test plan

- [x] New Jest suite `prefixWithRoot.test.ts` covering both forms, root with/without leading slash, trailing-slash stripping, empty-root error. 6 cases.
- [x] Full Jest suite green (15 tests / 4 suites).
- [x] `./gradlew build` green.

Closes #1012