### PR TITLE
Move npm publishing into build-and-publish #1058

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -18,6 +18,7 @@ jobs:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
           codecovToken: ${{ secrets.CODECOV_TOKEN }}
+          npmPublish: true
           releaseBranch: |
             master
             2.x
@@ -33,29 +34,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24.x'
-
-      - name: Set npm tag
-        run: |
-          VERSION=$(grep '^version' gradle.properties | cut -d'=' -f2 | tr -d ' ')
-          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "NPM_TAG=latest" >> $GITHUB_ENV
-          else
-            echo "NPM_TAG=beta" >> $GITHUB_ENV
-          fi
-
-      - name: Build
-        run: |
-          npm ci
-          npm run build
-
-      - name: Publish
-        run: npx -y npm@latest publish --tag $NPM_TAG
-        working-directory: build/types
 
       - uses: enonic/release-tools/release@master
         with:


### PR DESCRIPTION
Moves `@enonic-types/static` npm publishing out of the bespoke `release` job into the shared `build-and-publish` action via its `npmPublish` flag (enonic/release-tools#69), gated on `build-and-publish.outputs.release`.

- `build` job: pass `npmPublish: true`.
- `release` job: drop the Node setup / npm-tag / build / publish steps; keep only the GitHub `release@master`.

**Merge order:** land enonic/release-tools#69 first (the flag must exist on `@master`).

Closes #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)